### PR TITLE
[Mind-7] 전문가 등록 기능 구현

### DIFF
--- a/src/main/java/com/mindgoal/common/BaseResponseStatus.java
+++ b/src/main/java/com/mindgoal/common/BaseResponseStatus.java
@@ -6,12 +6,15 @@ import lombok.Getter;
 public enum BaseResponseStatus {
     // 200번대: 성공 응답
     SUCCESS(true, 200, "요청이 성공했습니다"),
+    EXPERT_REGISTER_SUCCESS(true, 201, "전문가 등록이 성공했습니다"),
 
     // 400번대: Request 오류
     BAD_REQUEST(false, 400, "잘못된 요청입니다"),
     UNAUTHORIZED(false, 401, "인증이 필요합니다"),
     NOT_FOUND(false, 404, "리소스를 찾을 수 없습니다"),
     METHOD_NOT_ALLOWED(false, 405, "허용되지 않은 메서드입니다"),
+    EXPERT_ALREADY_EXISTS(false, 409, "이미 등록된 전문가입니다"),
+    EXPERT_NOT_FOUND(false, 404, "전문가를 찾을 수 없습니다"),
 
     // 500번대: Server 오류
     INTERNAL_SERVER_ERROR(false, 500, "서버 내부 오류가 발생했습니다"),

--- a/src/main/java/com/mindgoal/domain/expert/controller/ExpertController.java
+++ b/src/main/java/com/mindgoal/domain/expert/controller/ExpertController.java
@@ -1,6 +1,7 @@
 package com.mindgoal.domain.expert.controller;
 
 import com.mindgoal.common.BaseResponse;
+import com.mindgoal.common.BaseResponseStatus;
 import com.mindgoal.domain.expert.dto.ExpertCreateRequest;
 import com.mindgoal.domain.expert.dto.ExpertResponse;
 import com.mindgoal.domain.expert.service.ExpertService;
@@ -13,7 +14,7 @@ import jakarta.validation.Valid;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/experts")
+@RequestMapping("/api/v1/expert")
 public class ExpertController {
     private final ExpertService expertService;
 
@@ -23,6 +24,6 @@ public class ExpertController {
         ExpertResponse response = expertService.register(request);
         return ResponseEntity
                 .status(HttpStatus.CREATED)
-                .body(BaseResponse.success(response, "전문가 등록 성공"));
+                .body(BaseResponse.success(response, BaseResponseStatus.EXPERT_REGISTER_SUCCESS.getMessage()));
     }
 }

--- a/src/main/java/com/mindgoal/domain/expert/controller/ExpertController.java
+++ b/src/main/java/com/mindgoal/domain/expert/controller/ExpertController.java
@@ -1,1 +1,28 @@
-package com.mindgoal.domain.expert.controller; 
+package com.mindgoal.domain.expert.controller;
+
+import com.mindgoal.common.BaseResponse;
+import com.mindgoal.domain.expert.dto.ExpertCreateRequest;
+import com.mindgoal.domain.expert.dto.ExpertResponse;
+import com.mindgoal.domain.expert.service.ExpertService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import jakarta.validation.Valid;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/experts")
+public class ExpertController {
+    private final ExpertService expertService;
+
+    @PostMapping
+    public ResponseEntity<BaseResponse<ExpertResponse>> register(
+            @RequestBody @Valid ExpertCreateRequest request) {
+        ExpertResponse response = expertService.register(request);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(BaseResponse.success(response, "전문가 등록 성공"));
+    }
+}

--- a/src/main/java/com/mindgoal/domain/expert/dto/ExpertCreateRequest.java
+++ b/src/main/java/com/mindgoal/domain/expert/dto/ExpertCreateRequest.java
@@ -1,0 +1,54 @@
+package com.mindgoal.domain.expert.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ExpertCreateRequest {
+    @NotBlank(message = "카테고리는 필수입니다")
+    private String category;
+
+    @NotBlank(message = "전문 분야는 필수입니다")
+    private String speciality;
+
+    @NotBlank(message = "포지션은 필수입니다")
+    private String position;
+
+    @Positive(message = "경력 연수는 양수여야 합니다")
+    private int careerYears;
+
+    @NotBlank(message = "설명은 필수입니다")
+    private String description;
+
+    private String careerHistory;
+
+    private String teachingMethod;
+
+    @Positive(message = "시간당 비용은 양수여야 합니다")
+    private int pricePerHour;
+
+    private String youtubeUrl;
+    private String instagramUrl;
+
+    @Builder
+    public ExpertCreateRequest(String category, String speciality,
+                               String position, int careerYears, String description,
+                               String careerHistory, String teachingMethod, int pricePerHour,
+                               String youtubeUrl, String instagramUrl) {
+        this.category = category;
+        this.speciality = speciality;
+        this.position = position;
+        this.careerYears = careerYears;
+        this.description = description;
+        this.careerHistory = careerHistory;
+        this.teachingMethod = teachingMethod;
+        this.pricePerHour = pricePerHour;
+        this.youtubeUrl = youtubeUrl;
+        this.instagramUrl = instagramUrl;
+    }
+}

--- a/src/main/java/com/mindgoal/domain/expert/dto/ExpertResponse.java
+++ b/src/main/java/com/mindgoal/domain/expert/dto/ExpertResponse.java
@@ -1,0 +1,52 @@
+package com.mindgoal.domain.expert.dto;
+
+import com.mindgoal.domain.expert.entity.Expert;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ExpertResponse {
+    private final Long id;
+    private final String category;
+    private final String speciality;
+    private final String position;
+    private final double rating;
+    private final int matchCount;
+    private final boolean isActive;
+    private final int physicalScore;
+    private final int techScore;
+    private final int mentalScore;
+
+    @Builder
+    private ExpertResponse(Long id, String category, String speciality,
+                           String position, double rating, int matchCount, boolean isActive,
+                           int physicalScore, int techScore, int mentalScore) {
+        this.id = id;
+        this.category = category;
+        this.speciality = speciality;
+        this.position = position;
+        this.rating = rating;
+        this.matchCount = matchCount;
+        this.isActive = isActive;
+        this.physicalScore = physicalScore;
+        this.techScore = techScore;
+        this.mentalScore = mentalScore;
+    }
+
+    public static ExpertResponse from(Expert expert) {
+        return ExpertResponse.builder()
+                .id(expert.getId())
+                .category(expert.getCategory())
+                .speciality(expert.getSpeciality())
+                .position(expert.getPosition())
+                .rating(expert.getRating())
+                .matchCount(expert.getMatchCount())
+                .isActive(expert.isActive())
+                .physicalScore(expert.getPhysicalScore())
+                .techScore(expert.getTechScore())
+                .mentalScore(expert.getMentalScore())
+                .build();
+    }
+
+
+}

--- a/src/main/java/com/mindgoal/domain/expert/entity/Expert.java
+++ b/src/main/java/com/mindgoal/domain/expert/entity/Expert.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.util.Objects;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -21,6 +22,9 @@ public class Expert extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "ID", nullable = false)
     private Long id;
+
+    @Column(name = "USER_ID", nullable = false)
+    private Long userId;
 
     @Column(name = "CAREER_YEARS")
     private int careerYears;
@@ -43,8 +47,8 @@ public class Expert extends BaseEntity {
     @Column(name = "RATING")
     private double rating;
 
-    @Column(name = "IS_ACTIVE")
-    private Boolean isActive;
+    @Column(name = "IS_ACTIVE", nullable = false)
+    private boolean isActive = false;
 
     @Column(name = "CATEGORY")
     private String category;
@@ -64,11 +68,36 @@ public class Expert extends BaseEntity {
     @Column(name = "SPECIALITY")
     private String speciality;
 
-    @Column(name = "TEACHING_POSITION")
-    private String teachingPosition;
+    @Column(name = "TEACHING_METHOD")
+    private String teachingMethod;
 
     @Column(name = "YOUTUBE_URL")
     private String youtubeUrl;
+
+    @Builder
+    public Expert(Long userId,String category, String speciality, String position,
+                  int careerYears, String description, String careerHistory,
+                  String teachingMethod, int pricePerHour, String youtubeUrl,
+                  String instagramUrl, Boolean isActive, double rating, int matchCount,
+                  int physicalScore, int techScore, int mentalScore) {
+        this.userId = userId;
+        this.category = category;
+        this.speciality = speciality;
+        this.position = position;
+        this.careerYears = careerYears;
+        this.description = description;
+        this.careerHistory = careerHistory;
+        this.teachingMethod = teachingMethod;
+        this.pricePerHour = pricePerHour;
+        this.youtubeUrl = youtubeUrl;
+        this.instagramUrl = instagramUrl;
+        this.isActive = (isActive != null) ? isActive : false;
+        this.rating = rating;
+        this.matchCount = matchCount;
+        this.physicalScore = physicalScore;
+        this.techScore = techScore;
+        this.mentalScore = mentalScore;
+    }
 
     @Override
     public boolean equals(Object object) {

--- a/src/main/java/com/mindgoal/domain/expert/repository/ExpertRepository.java
+++ b/src/main/java/com/mindgoal/domain/expert/repository/ExpertRepository.java
@@ -1,1 +1,10 @@
-package com.mindgoal.domain.expert.repository; 
+package com.mindgoal.domain.expert.repository;
+
+import com.mindgoal.domain.expert.entity.Expert;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ExpertRepository extends JpaRepository<Expert, Long> {
+    boolean existsByUserId(Long userId);
+}

--- a/src/main/java/com/mindgoal/domain/expert/service/ExpertService.java
+++ b/src/main/java/com/mindgoal/domain/expert/service/ExpertService.java
@@ -1,1 +1,52 @@
-package com.mindgoal.domain.expert.service; 
+package com.mindgoal.domain.expert.service;
+
+import com.mindgoal.domain.expert.dto.ExpertCreateRequest;
+import com.mindgoal.domain.expert.dto.ExpertResponse;
+import com.mindgoal.domain.expert.entity.Expert;
+import com.mindgoal.domain.expert.repository.ExpertRepository;
+import com.mindgoal.domain.user.entity.User;
+import com.mindgoal.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ExpertService {
+    private final ExpertRepository expertRepository;
+    private final UserService userService;
+        @Transactional
+        public ExpertResponse register(ExpertCreateRequest request) {
+            // 현재 로그인한 사용자 정보 가져오기
+            User currentUser = userService.getCurrentUser();
+
+            // 이미 전문가로 등록된 사용자인지 확인
+            if (expertRepository.existsByUserId(currentUser.getId())) {
+                throw new IllegalArgumentException("이미 등록된 전문가입니다.");
+            }
+
+            Expert expert = Expert.builder()
+                    .userId(currentUser.getId())
+                    .category(request.getCategory())
+                    .speciality(request.getSpeciality())
+                    .position(request.getPosition())
+                    .careerYears(request.getCareerYears())
+                    .description(request.getDescription())
+                    .careerHistory(request.getCareerHistory())
+                    .teachingMethod(request.getTeachingMethod())
+                    .pricePerHour(request.getPricePerHour())
+                    .youtubeUrl(request.getYoutubeUrl())
+                    .instagramUrl(request.getInstagramUrl())
+                    .isActive(true)
+                    .build();
+
+            Expert savedExpert = expertRepository.save(expert);
+            return ExpertResponse.from(savedExpert);
+        }
+
+    public Expert getExpert(Long id) {
+        return expertRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("전문가를 찾을 수 없습니다."));
+    }
+}

--- a/src/main/java/com/mindgoal/domain/expert/service/ExpertService.java
+++ b/src/main/java/com/mindgoal/domain/expert/service/ExpertService.java
@@ -1,52 +1,55 @@
 package com.mindgoal.domain.expert.service;
 
+import com.mindgoal.common.BaseResponseStatus;
 import com.mindgoal.domain.expert.dto.ExpertCreateRequest;
 import com.mindgoal.domain.expert.dto.ExpertResponse;
 import com.mindgoal.domain.expert.entity.Expert;
 import com.mindgoal.domain.expert.repository.ExpertRepository;
 import com.mindgoal.domain.user.entity.User;
 import com.mindgoal.domain.user.service.UserService;
+import com.mindgoal.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class ExpertService {
     private final ExpertRepository expertRepository;
     private final UserService userService;
-        @Transactional
-        public ExpertResponse register(ExpertCreateRequest request) {
-            // 현재 로그인한 사용자 정보 가져오기
-            User currentUser = userService.getCurrentUser();
 
-            // 이미 전문가로 등록된 사용자인지 확인
-            if (expertRepository.existsByUserId(currentUser.getId())) {
-                throw new IllegalArgumentException("이미 등록된 전문가입니다.");
-            }
+    @Transactional
+    public ExpertResponse register(ExpertCreateRequest request) {
+        User currentUser = userService.getCurrentUser();
 
-            Expert expert = Expert.builder()
-                    .userId(currentUser.getId())
-                    .category(request.getCategory())
-                    .speciality(request.getSpeciality())
-                    .position(request.getPosition())
-                    .careerYears(request.getCareerYears())
-                    .description(request.getDescription())
-                    .careerHistory(request.getCareerHistory())
-                    .teachingMethod(request.getTeachingMethod())
-                    .pricePerHour(request.getPricePerHour())
-                    .youtubeUrl(request.getYoutubeUrl())
-                    .instagramUrl(request.getInstagramUrl())
-                    .isActive(true)
-                    .build();
-
-            Expert savedExpert = expertRepository.save(expert);
-            return ExpertResponse.from(savedExpert);
+        if (expertRepository.existsByUserId(currentUser.getId())) {
+            throw new CustomException(BaseResponseStatus.EXPERT_ALREADY_EXISTS);
         }
+
+        Expert expert = createExpertEntity(currentUser, request);
+        Expert savedExpert = expertRepository.save(expert);
+        return ExpertResponse.from(savedExpert);
+    }
 
     public Expert getExpert(Long id) {
         return expertRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("전문가를 찾을 수 없습니다."));
+                .orElseThrow(() -> new CustomException(BaseResponseStatus.EXPERT_NOT_FOUND));
+    }
+
+    private Expert createExpertEntity(User user, ExpertCreateRequest request) {
+        return Expert.builder()
+                .userId(user.getId())
+                .category(request.getCategory())
+                .speciality(request.getSpeciality())
+                .position(request.getPosition())
+                .careerYears(request.getCareerYears())
+                .description(request.getDescription())
+                .careerHistory(request.getCareerHistory())
+                .teachingMethod(request.getTeachingMethod())
+                .pricePerHour(request.getPricePerHour())
+                .youtubeUrl(request.getYoutubeUrl())
+                .instagramUrl(request.getInstagramUrl())
+                .isActive(true)
+                .build();
     }
 }

--- a/src/main/java/com/mindgoal/exception/CustomException.java
+++ b/src/main/java/com/mindgoal/exception/CustomException.java
@@ -1,1 +1,14 @@
- 
+package com.mindgoal.exception;
+
+import com.mindgoal.common.BaseResponseStatus;
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final BaseResponseStatus status;
+
+    public CustomException(BaseResponseStatus status) {
+        super(status.getMessage());
+        this.status = status;
+    }
+}

--- a/src/test/java/com/mindgoal/backend/expert/service/ExpertServiceTest.java
+++ b/src/test/java/com/mindgoal/backend/expert/service/ExpertServiceTest.java
@@ -1,0 +1,169 @@
+package com.mindgoal.backend.expert.service;
+
+import com.mindgoal.backend.support.annotation.ServiceTest;
+import com.mindgoal.domain.expert.dto.ExpertCreateRequest;
+import com.mindgoal.domain.expert.dto.ExpertResponse;
+import com.mindgoal.domain.expert.entity.Expert;
+import com.mindgoal.domain.expert.repository.ExpertRepository;
+import com.mindgoal.domain.expert.service.ExpertService;
+import com.mindgoal.domain.user.entity.User;
+import com.mindgoal.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ServiceTest
+class ExpertServiceTest {
+
+    @Autowired
+    private ExpertService expertService;
+
+    @Autowired
+    private ExpertRepository expertRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @MockBean
+    private SecurityContext securityContext;
+
+    @MockBean
+    private Authentication authentication;
+
+    @BeforeEach
+    void setUp() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @DisplayName("전문가 등록 성공")
+    @Test
+    void register_Success() {
+        // given
+        User user = createUser("test@example.com", "testUser");
+        setSecurityContext(user.getEmail());
+        ExpertCreateRequest request = createExpertRequest();
+
+        // when
+        ExpertResponse response = expertService.register(request);
+
+        // then
+        assertThat(response)
+                .satisfies(expertResponse -> {
+                    assertThat(expertResponse.getCategory()).isEqualTo("TECHNICAL");
+                    assertThat(expertResponse.getSpeciality()).isEqualTo("축구 기술 트레이닝");
+                    assertThat(expertResponse.getPosition()).isEqualTo("공격수");
+                    assertThat(expertResponse.getRating()).isEqualTo(0.0);
+                    assertThat(expertResponse.getMatchCount()).isEqualTo(0);
+                    assertThat(expertResponse.isActive()).isTrue();
+                    assertThat(expertResponse.getPhysicalScore()).isEqualTo(0);
+                    assertThat(expertResponse.getTechScore()).isEqualTo(0);
+                    assertThat(expertResponse.getMentalScore()).isEqualTo(0);
+                });
+
+        // DB 검증
+        Expert foundExpert = expertRepository.findById(response.getId())
+                .orElseThrow(() -> new AssertionError("Expert should exist"));
+        assertThat(foundExpert)
+                .satisfies(expert -> {
+                    assertThat(expert.getCategory()).isEqualTo("TECHNICAL");
+                    assertThat(expert.getSpeciality()).isEqualTo("축구 기술 트레이닝");
+                    assertThat(expert.getPosition()).isEqualTo("공격수");
+                    assertThat(expert.getCareerYears()).isEqualTo(5);
+                });
+    }
+
+    @DisplayName("이미 등록된 전문가인 경우 실패")
+    @Test
+    void register_AlreadyExistExpert_ThrowsException() {
+        // given
+        User user = createUser("test@example.com", "testUser");
+        setSecurityContext(user.getEmail());
+        Expert expert = createExpert(user.getId());
+        ExpertCreateRequest request = createExpertRequest();
+
+        // when & then
+        assertThrows(IllegalArgumentException.class,
+                () -> expertService.register(request));
+    }
+
+    @DisplayName("전문가 등록시 초기값 설정 확인")
+    @Test
+    void register_CheckInitialValues() {
+        // given
+        User user = createUser("test@example.com", "testUser");
+        setSecurityContext(user.getEmail());
+        ExpertCreateRequest request = createExpertRequest();
+
+        // when
+        ExpertResponse response = expertService.register(request);
+
+        // then
+        assertThat(response)
+                .satisfies(expertResponse -> {
+                    assertThat(expertResponse.getRating()).isEqualTo(0.0);
+                    assertThat(expertResponse.getMatchCount()).isEqualTo(0);
+                    assertThat(expertResponse.isActive()).isTrue();
+                    assertThat(expertResponse.getPhysicalScore()).isEqualTo(0);
+                    assertThat(expertResponse.getTechScore()).isEqualTo(0);
+                    assertThat(expertResponse.getMentalScore()).isEqualTo(0);
+                });
+    }
+
+    private void setSecurityContext(String email) {
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+        when(authentication.getName()).thenReturn(email);
+        SecurityContextHolder.setContext(securityContext);
+    }
+
+    private User createUser(String email, String name) {
+        User user = User.builder()
+                .email(email)
+                .password("password1234")
+                .name(name)
+                .build();
+        return userRepository.save(user);
+    }
+
+    private Expert createExpert(Long userId) {
+        Expert expert = Expert.builder()
+                .userId(userId)
+                .category("TECHNICAL")
+                .speciality("축구 기술 트레이닝")
+                .position("공격수")
+                .careerYears(5)
+                .description("전문가 설명")
+                .careerHistory("경력 사항")
+                .teachingMethod("교육 방식")
+                .pricePerHour(50000)
+                .isActive(true)
+                .rating(0.0)
+                .matchCount(0)
+                .physicalScore(0)
+                .techScore(0)
+                .mentalScore(0)
+                .build();
+        return expertRepository.save(expert);
+    }
+
+    private ExpertCreateRequest createExpertRequest() {
+        return ExpertCreateRequest.builder()
+                .category("TECHNICAL")
+                .speciality("축구 기술 트레이닝")
+                .position("공격수")
+                .careerYears(5)
+                .description("10년 이상의 축구 선수 경력")
+                .careerHistory("프로팀 경력 5년")
+                .teachingMethod("1:1 맞춤형 기술 훈련")
+                .pricePerHour(50000)
+                .build();
+    }
+}

--- a/src/test/java/com/mindgoal/backend/user/service/UserServiceTest.java
+++ b/src/test/java/com/mindgoal/backend/user/service/UserServiceTest.java
@@ -1,21 +1,25 @@
-package com.mindgoal.backend.user;
+package com.mindgoal.backend.user.service;
 
 import com.mindgoal.domain.user.dto.UpdateUserRequest;
 import com.mindgoal.domain.user.entity.User;
 import com.mindgoal.domain.user.repository.UserRepository;
 import com.mindgoal.domain.user.service.UserService;
 import com.mindgoal.backend.support.annotation.ServiceTest;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
 
 @ServiceTest
-@Transactional
 class UserServiceTest {
 
     @Autowired
@@ -24,11 +28,23 @@ class UserServiceTest {
     @Autowired
     private UserRepository userRepository;
 
+    @MockBean
+    private SecurityContext securityContext;
+
+    @MockBean
+    private Authentication authentication;
+
+    @BeforeEach
+    void setUp() {
+        SecurityContextHolder.clearContext();
+    }
+
     @DisplayName("사용자 정보 업데이트 성공")
     @Test
     void updateUser_Success() {
         // given
         User savedUser = createUser("test@example.com", "oldName", "old.jpg");
+        setSecurityContext(savedUser.getEmail());
 
         UpdateUserRequest request = UpdateUserRequest.builder()
                 .name("newName")
@@ -55,6 +71,9 @@ class UserServiceTest {
     @Test
     void updateUser_UserNotFound_ThrowsException() {
         // given
+        String nonExistentEmail = "nonexistent@example.com";
+        setSecurityContext(nonExistentEmail);
+
         UpdateUserRequest request = UpdateUserRequest.builder()
                 .name("newName")
                 .profileImage("newImage.jpg")
@@ -70,6 +89,7 @@ class UserServiceTest {
     void updateUser_NameOnly() {
         // given
         User savedUser = createUser("test@example.com", "oldName", "old.jpg");
+        setSecurityContext(savedUser.getEmail());
 
         UpdateUserRequest request = UpdateUserRequest.builder()
                 .name("newName")
@@ -82,6 +102,12 @@ class UserServiceTest {
         assertThat(updatedUser)
                 .extracting("name", "profileImage")
                 .containsExactly("newName", "old.jpg");
+    }
+
+    private void setSecurityContext(String email) {
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+        when(authentication.getName()).thenReturn(email);
+        SecurityContextHolder.setContext(securityContext);
     }
 
     private User createUser(String email, String name, String profileImage) {


### PR DESCRIPTION

# **Pull Request**

## 💡 PR 요약
전문가 등록 기능을 구현하고, `UserServiceTest`를 리팩토링하였습니다.

## 🔍 주요 변경사항
### **1. 전문가 등록 기능 추가**
- `Expert` 엔티티 및 관련 DTO (`ExpertCreateRequest`, `ExpertResponse`) 추가
- `ExpertController`, `ExpertService`, `ExpertRepository` 구현
- `ExpertServiceTest` 단위 테스트 작성

### **2. `UserServiceTest` 리팩토링**
- `UserServiceTest` 위치 이동 (`src/test/java/com/mindgoal/backend/user/service/`)
- 테스트 코드 가독성 개선 및 코드 리팩토링

## 🔗 연관된 이슈
- close #이슈번호

## 📸 스크린샷 (선택)
(필요하면 스크린샷 첨부)

## ✅ 체크리스트
- [x] 테스트 코드를 작성하였나요?
- [x] 관련 문서를 업데이트하였나요?
- [ ] Breaking Change가 있나요?
- [x] 코드 포맷팅과 린트 검사를 완료하였나요?

## 🙏 리뷰어 참고사항
- `ExpertService` 로직이 적절한지 확인 부탁드립니다.
- `UserServiceTest` 리팩토링 방향이 적절한지 검토 부탁드립니다.

## 📋 추가 컨텍스트 (선택)
- 전문가 등록 기능에 대한 추가적인 개선 사항이 있다면 의견 부탁드립니다.

