### PR TITLE
[Mind-10] 전문가 정보 수정 구현

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'Mind-Goal-Backend'
+rootProject.name = 'mind-goal-backend'

--- a/src/main/java/com/mindgoal/MindGoalBackendApplication.java
+++ b/src/main/java/com/mindgoal/MindGoalBackendApplication.java
@@ -2,8 +2,10 @@ package com.mindgoal;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class MindGoalBackendApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/mindgoal/common/BaseResponseStatus.java
+++ b/src/main/java/com/mindgoal/common/BaseResponseStatus.java
@@ -7,6 +7,7 @@ public enum BaseResponseStatus {
     // 200번대: 성공 응답
     SUCCESS(true, 200, "요청이 성공했습니다"),
     EXPERT_REGISTER_SUCCESS(true, 201, "전문가 등록이 성공했습니다"),
+    EXPERT_DETAIL_SUCCESS(true, 200, "전문가 상세 조회에 성공하였습니다"),
 
     // 400번대: Request 오류
     BAD_REQUEST(false, 400, "잘못된 요청입니다"),

--- a/src/main/java/com/mindgoal/common/BaseResponseStatus.java
+++ b/src/main/java/com/mindgoal/common/BaseResponseStatus.java
@@ -8,10 +8,12 @@ public enum BaseResponseStatus {
     SUCCESS(true, 200, "요청이 성공했습니다"),
     EXPERT_REGISTER_SUCCESS(true, 201, "전문가 등록이 성공했습니다"),
     EXPERT_DETAIL_SUCCESS(true, 200, "전문가 상세 조회에 성공하였습니다"),
+    EXPERT_UPDATE_SUCCESS(true, 200, "전문가 정보 수정이 성공했습니다"),
 
     // 400번대: Request 오류
     BAD_REQUEST(false, 400, "잘못된 요청입니다"),
     UNAUTHORIZED(false, 401, "인증이 필요합니다"),
+    UNAUTHORIZED_ACCESS(false, 403, "해당 리소스에 대한 권한이 없습니다"),
     NOT_FOUND(false, 404, "리소스를 찾을 수 없습니다"),
     METHOD_NOT_ALLOWED(false, 405, "허용되지 않은 메서드입니다"),
     EXPERT_ALREADY_EXISTS(false, 409, "이미 등록된 전문가입니다"),

--- a/src/main/java/com/mindgoal/domain/expert/controller/ExpertController.java
+++ b/src/main/java/com/mindgoal/domain/expert/controller/ExpertController.java
@@ -26,7 +26,7 @@ public class ExpertController {
         ExpertResponse response = expertService.register(request);
         return ResponseEntity
                 .status(HttpStatus.CREATED)
-                .body(BaseResponse.success(response, BaseResponseStatus.EXPERT_REGISTER_SUCCESS.getMessage()));  // 응답 메시지 통일
+                .body(BaseResponse.success(response, BaseResponseStatus.EXPERT_REGISTER_SUCCESS.getMessage()));
     }
 
     @GetMapping
@@ -63,8 +63,15 @@ public class ExpertController {
         return ResponseEntity.ok(
                 BaseResponse.success(response, BaseResponseStatus.EXPERT_DETAIL_SUCCESS.getMessage())
         );
-
     }
 
+    @PutMapping("/{Id}")
+    public ResponseEntity<BaseResponse<ExpertUpdateResponse>> updateExpert(
+            @PathVariable Long expertId,
+            @RequestBody @Valid ExpertUpdateRequest request) {
+        ExpertUpdateResponse response = expertService.updateExpert(expertId, request);
+        return ResponseEntity.ok(
+                BaseResponse.success(response, BaseResponseStatus.EXPERT_UPDATE_SUCCESS.getMessage())
+        );
+    }
 }
-

--- a/src/main/java/com/mindgoal/domain/expert/controller/ExpertController.java
+++ b/src/main/java/com/mindgoal/domain/expert/controller/ExpertController.java
@@ -2,10 +2,7 @@ package com.mindgoal.domain.expert.controller;
 
 import com.mindgoal.common.BaseResponse;
 import com.mindgoal.common.BaseResponseStatus;
-import com.mindgoal.domain.expert.dto.ExpertCreateRequest;
-import com.mindgoal.domain.expert.dto.ExpertListResponse;
-import com.mindgoal.domain.expert.dto.ExpertResponse;
-import com.mindgoal.domain.expert.dto.ExpertSearchCondition;
+import com.mindgoal.domain.expert.dto.*;
 import com.mindgoal.domain.expert.service.ExpertService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -58,4 +55,16 @@ public class ExpertController {
         Page<ExpertListResponse> response = expertService.searchExperts(condition, pageable);
         return ResponseEntity.ok(BaseResponse.success(response, "전문가 목록 조회 성공"));
     }
+
+    @GetMapping("/{Id}")
+    public ResponseEntity<BaseResponse<ExpertDetailResponse>> getExpertDetail(
+            @PathVariable Long expertId) {
+        ExpertDetailResponse response = expertService.getExpertDetail(expertId);
+        return ResponseEntity.ok(
+                BaseResponse.success(response, BaseResponseStatus.EXPERT_DETAIL_SUCCESS.getMessage())
+        );
+
+    }
+
 }
+

--- a/src/main/java/com/mindgoal/domain/expert/dto/ExpertDetailResponse.java
+++ b/src/main/java/com/mindgoal/domain/expert/dto/ExpertDetailResponse.java
@@ -1,0 +1,76 @@
+package com.mindgoal.domain.expert.dto;
+
+import com.mindgoal.domain.expert.entity.Expert;
+import lombok.Builder;
+import lombok.Getter;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ExpertDetailResponse {
+    private Long id;
+    private Long userId;
+    private String name;
+    private String position;
+    private String category;
+    private String region;
+    private String speciality;
+    private String description;
+    private String careerHistory;
+    private String teachingMethod;
+    private int careerYears;
+    private int matchCount;
+    private double rating;
+    private boolean isActive;
+    private int pricePerHour;
+    private Scores scores;
+    private Links links;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    @Getter
+    @Builder
+    public static class Scores {
+        private int physical;
+        private int tech;
+        private int mental;
+    }
+
+    @Getter
+    @Builder
+    public static class Links {
+        private String youtube;
+        private String instagram;
+    }
+
+    public static ExpertDetailResponse from(Expert expert, String userName) {
+        return ExpertDetailResponse.builder()
+                .id(expert.getId())
+                .userId(expert.getUserId())
+                .name(userName)
+                .position(expert.getPosition())
+                .category(expert.getCategory())
+                .region(expert.getRegion())
+                .speciality(expert.getSpeciality())
+                .description(expert.getDescription())
+                .careerHistory(expert.getCareerHistory())
+                .teachingMethod(expert.getTeachingMethod())
+                .careerYears(expert.getCareerYears())
+                .matchCount(expert.getMatchCount())
+                .rating(expert.getRating())
+                .isActive(expert.isActive())
+                .pricePerHour(expert.getPricePerHour())
+                .scores(Scores.builder()
+                        .physical(expert.getPhysicalScore())
+                        .tech(expert.getTechScore())
+                        .mental(expert.getMentalScore())
+                        .build())
+                .links(Links.builder()
+                        .youtube(expert.getYoutubeUrl())
+                        .instagram(expert.getInstagramUrl())
+                        .build())
+                .createdAt(expert.getCreatedAt())
+                .updatedAt(expert.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/mindgoal/domain/expert/dto/ExpertUpdateRequest.java
+++ b/src/main/java/com/mindgoal/domain/expert/dto/ExpertUpdateRequest.java
@@ -1,0 +1,22 @@
+package com.mindgoal.domain.expert.dto;
+
+import jakarta.validation.constraints.Min;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExpertUpdateRequest {
+    private String specialty;
+    private String position;
+    private String description;
+    private String careerHistory;
+    private String teachingMethod;
+    private Integer pricePerHour;
+    private String youtubeUrl;
+    private String instagramUrl;
+}

--- a/src/main/java/com/mindgoal/domain/expert/dto/ExpertUpdateResponse.java
+++ b/src/main/java/com/mindgoal/domain/expert/dto/ExpertUpdateResponse.java
@@ -1,0 +1,21 @@
+package com.mindgoal.domain.expert.dto;
+
+import com.mindgoal.domain.expert.entity.Expert;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ExpertUpdateResponse {
+    private Long id;
+    private LocalDateTime updatedAt;
+
+    public static ExpertUpdateResponse from(Expert expert) {
+        return ExpertUpdateResponse.builder()
+                .id(expert.getId())
+                .updatedAt(expert.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/mindgoal/domain/expert/entity/Expert.java
+++ b/src/main/java/com/mindgoal/domain/expert/entity/Expert.java
@@ -103,6 +103,26 @@ public class Expert extends BaseEntity {
         this.mentalScore = mentalScore;
     }
 
+    public void update(
+            String specialty,
+            String position,
+            String description,
+            String careerHistory,
+            String teachingMethod,
+            Integer pricePerHour,
+            String youtubeUrl,
+            String instagramUrl
+    ) {
+        if (specialty != null) this.speciality = specialty;
+        if (position != null) this.position = position;
+        if (description != null) this.description = description;
+        if (careerHistory != null) this.careerHistory = careerHistory;
+        if (teachingMethod != null) this.teachingMethod = teachingMethod;
+        if (pricePerHour != null) this.pricePerHour = pricePerHour;
+        if (youtubeUrl != null) this.youtubeUrl = youtubeUrl;
+        if (instagramUrl != null) this.instagramUrl = instagramUrl;
+    }
+
     @Override
     public boolean equals(Object object) {
         if (this == object) {

--- a/src/main/java/com/mindgoal/domain/expert/service/ExpertService.java
+++ b/src/main/java/com/mindgoal/domain/expert/service/ExpertService.java
@@ -61,6 +61,39 @@ public class ExpertService {
         });
     }
 
+    @Transactional(readOnly = true)
+    public ExpertDetailResponse getExpertDetail(Long expertId) {
+        Expert expert = expertRepository.findById(expertId)
+                .orElseThrow(() -> new CustomException(BaseResponseStatus.EXPERT_NOT_FOUND));
+
+        User user = userService.getUser(expert.getUserId());
+        return ExpertDetailResponse.from(expert, user.getName());
+    }
+
+    @Transactional
+    public ExpertUpdateResponse updateExpert(Long expertId, ExpertUpdateRequest request) {
+        Expert expert = getExpert(expertId);
+        User currentUser = userService.getCurrentUser();
+
+        // Verify if the current user owns this expert profile
+        if (!expert.getUserId().equals(currentUser.getId())) {
+            throw new CustomException(BaseResponseStatus.UNAUTHORIZED_ACCESS);
+        }
+
+        expert.update(
+                request.getSpecialty(),
+                request.getPosition(),
+                request.getDescription(),
+                request.getCareerHistory(),
+                request.getTeachingMethod(),
+                request.getPricePerHour(),
+                request.getYoutubeUrl(),
+                request.getInstagramUrl()
+        );
+
+        return ExpertUpdateResponse.from(expert);
+    }
+
     private Expert createExpertEntity(User user, ExpertCreateRequest request) {
         return Expert.builder()
                 .userId(user.getId())
@@ -83,13 +116,4 @@ public class ExpertService {
                 .mentalScore(0)
                 .build();
     }
-    @Transactional(readOnly = true)
-    public ExpertDetailResponse getExpertDetail(Long expertId) {
-        Expert expert = expertRepository.findById(expertId)
-                .orElseThrow(() -> new CustomException(BaseResponseStatus.EXPERT_NOT_FOUND));
-
-        User user = userService.getUser(expert.getUserId());
-        return ExpertDetailResponse.from(expert, user.getName());
-    }
-
 }

--- a/src/main/java/com/mindgoal/domain/expert/service/ExpertService.java
+++ b/src/main/java/com/mindgoal/domain/expert/service/ExpertService.java
@@ -1,10 +1,7 @@
 package com.mindgoal.domain.expert.service;
 
 import com.mindgoal.common.BaseResponseStatus;
-import com.mindgoal.domain.expert.dto.ExpertCreateRequest;
-import com.mindgoal.domain.expert.dto.ExpertListResponse;
-import com.mindgoal.domain.expert.dto.ExpertResponse;
-import com.mindgoal.domain.expert.dto.ExpertSearchCondition;
+import com.mindgoal.domain.expert.dto.*;
 import com.mindgoal.domain.expert.entity.Expert;
 import com.mindgoal.domain.expert.repository.ExpertRepository;
 import com.mindgoal.domain.user.entity.User;
@@ -86,4 +83,13 @@ public class ExpertService {
                 .mentalScore(0)
                 .build();
     }
+    @Transactional(readOnly = true)
+    public ExpertDetailResponse getExpertDetail(Long expertId) {
+        Expert expert = expertRepository.findById(expertId)
+                .orElseThrow(() -> new CustomException(BaseResponseStatus.EXPERT_NOT_FOUND));
+
+        User user = userService.getUser(expert.getUserId());
+        return ExpertDetailResponse.from(expert, user.getName());
+    }
+
 }

--- a/src/test/java/com/mindgoal/backend/expert/service/ExpertServiceTest.java
+++ b/src/test/java/com/mindgoal/backend/expert/service/ExpertServiceTest.java
@@ -2,17 +2,19 @@ package com.mindgoal.backend.expert.service;
 
 import com.mindgoal.backend.support.annotation.ServiceTest;
 import com.mindgoal.domain.expert.dto.ExpertCreateRequest;
+import com.mindgoal.domain.expert.dto.ExpertDetailResponse;
 import com.mindgoal.domain.expert.dto.ExpertResponse;
 import com.mindgoal.domain.expert.entity.Expert;
 import com.mindgoal.domain.expert.repository.ExpertRepository;
 import com.mindgoal.domain.expert.service.ExpertService;
 import com.mindgoal.domain.user.entity.User;
 import com.mindgoal.domain.user.repository.UserRepository;
+import com.mindgoal.exception.CustomException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -33,20 +35,17 @@ class ExpertServiceTest {
     @Autowired
     private UserRepository userRepository;
 
-    @MockBean
+    @Mock
     private SecurityContext securityContext;
 
-    @MockBean
+    @Mock
     private Authentication authentication;
 
     @BeforeEach
     void setUp() {
         SecurityContextHolder.clearContext();
-<<<<<<< HEAD
         expertRepository.deleteAll();
         userRepository.deleteAll();
-=======
->>>>>>> deploy
     }
 
     @DisplayName("전문가 등록 성공")
@@ -66,10 +65,7 @@ class ExpertServiceTest {
                     assertThat(expertResponse.getCategory()).isEqualTo("TECHNICAL");
                     assertThat(expertResponse.getSpeciality()).isEqualTo("축구 기술 트레이닝");
                     assertThat(expertResponse.getPosition()).isEqualTo("공격수");
-<<<<<<< HEAD
                     assertThat(expertResponse.getRegion()).isEqualTo("서울");
-=======
->>>>>>> deploy
                     assertThat(expertResponse.getRating()).isEqualTo(0.0);
                     assertThat(expertResponse.getMatchCount()).isEqualTo(0);
                     assertThat(expertResponse.isActive()).isTrue();
@@ -86,10 +82,7 @@ class ExpertServiceTest {
                     assertThat(expert.getCategory()).isEqualTo("TECHNICAL");
                     assertThat(expert.getSpeciality()).isEqualTo("축구 기술 트레이닝");
                     assertThat(expert.getPosition()).isEqualTo("공격수");
-<<<<<<< HEAD
                     assertThat(expert.getRegion()).isEqualTo("서울");
-=======
->>>>>>> deploy
                     assertThat(expert.getCareerYears()).isEqualTo(5);
                 });
     }
@@ -104,7 +97,7 @@ class ExpertServiceTest {
         ExpertCreateRequest request = createExpertRequest();
 
         // when & then
-        assertThrows(IllegalArgumentException.class,
+        assertThrows(CustomException.class,
                 () -> expertService.register(request));
     }
 
@@ -131,6 +124,79 @@ class ExpertServiceTest {
                 });
     }
 
+    @DisplayName("전문가 상세 조회 성공")
+    @Test
+    void getExpertDetail_Success() {
+        // given
+        User user = createUser("test@example.com", "testUser");
+        Expert expert = createExpert(user.getId());
+
+        // when
+        ExpertDetailResponse response = expertService.getExpertDetail(expert.getId());
+
+        // then
+        assertThat(response.getId()).isEqualTo(expert.getId());
+        assertThat(response.getUserId()).isEqualTo(user.getId());
+        assertThat(response.getName()).isEqualTo(user.getName());
+        assertThat(response.getCategory()).isEqualTo("TECHNICAL");
+        assertThat(response.getSpeciality()).isEqualTo("축구 기술 트레이닝");
+        assertThat(response.getPosition()).isEqualTo("공격수");
+        assertThat(response.getRegion()).isEqualTo("서울");
+        assertThat(response.getCareerYears()).isEqualTo(5);
+        assertThat(response.getDescription()).isEqualTo("전문가 설명");
+        assertThat(response.getCareerHistory()).isEqualTo("경력 사항");
+        assertThat(response.getTeachingMethod()).isEqualTo("교육 방식");
+        assertThat(response.getPricePerHour()).isEqualTo(50000);
+
+        // Scores
+        assertThat(response.getScores())
+                .extracting("physical", "tech", "mental")
+                .containsExactly(0, 0, 0);
+
+        // Links
+        assertThat(response.getLinks())
+                .extracting("youtube", "instagram")
+                .containsOnlyNulls();
+
+        // Status
+        assertThat(response.isActive()).isTrue();
+        assertThat(response.getRating()).isZero();
+        assertThat(response.getMatchCount()).isZero();
+
+        // Timestamps
+        assertThat(response.getCreatedAt()).isNotNull();
+        assertThat(response.getUpdatedAt()).isNotNull();
+    }
+
+    @DisplayName("존재하지 않는 전문가 조회시 실패")
+    @Test
+    void getExpertDetail_NotFound_ThrowsException() {
+        // given
+        Long nonExistentExpertId = 999L;
+
+        // when & then
+        assertThrows(CustomException.class,
+                () -> expertService.getExpertDetail(nonExistentExpertId));
+    }
+
+    @DisplayName("전문가 상세 조회시 연관된 사용자 정보 확인")
+    @Test
+    void getExpertDetail_CheckUserInfo() {
+        // given
+        User user = createUser("test@example.com", "testUser");
+        Expert expert = createExpert(user.getId());
+
+        // when
+        ExpertDetailResponse response = expertService.getExpertDetail(expert.getId());
+
+        // then
+        assertThat(response)
+                .satisfies(expertResponse -> {
+                    assertThat(expertResponse.getUserId()).isEqualTo(user.getId());
+                    assertThat(expertResponse.getName()).isEqualTo(user.getName());
+                });
+    }
+
     private void setSecurityContext(String email) {
         when(securityContext.getAuthentication()).thenReturn(authentication);
         when(authentication.getName()).thenReturn(email);
@@ -142,10 +208,7 @@ class ExpertServiceTest {
                 .email(email)
                 .password("password1234")
                 .name(name)
-<<<<<<< HEAD
                 .isAgreePolicy(true)
-=======
->>>>>>> deploy
                 .build();
         return userRepository.save(user);
     }
@@ -156,10 +219,7 @@ class ExpertServiceTest {
                 .category("TECHNICAL")
                 .speciality("축구 기술 트레이닝")
                 .position("공격수")
-<<<<<<< HEAD
                 .region("서울")
-=======
->>>>>>> deploy
                 .careerYears(5)
                 .description("전문가 설명")
                 .careerHistory("경력 사항")
@@ -180,10 +240,7 @@ class ExpertServiceTest {
                 .category("TECHNICAL")
                 .speciality("축구 기술 트레이닝")
                 .position("공격수")
-<<<<<<< HEAD
                 .region("서울")
-=======
->>>>>>> deploy
                 .careerYears(5)
                 .description("10년 이상의 축구 선수 경력")
                 .careerHistory("프로팀 경력 5년")

--- a/src/test/java/com/mindgoal/backend/expert/service/ExpertServiceTest.java
+++ b/src/test/java/com/mindgoal/backend/expert/service/ExpertServiceTest.java
@@ -1,9 +1,7 @@
 package com.mindgoal.backend.expert.service;
 
 import com.mindgoal.backend.support.annotation.ServiceTest;
-import com.mindgoal.domain.expert.dto.ExpertCreateRequest;
-import com.mindgoal.domain.expert.dto.ExpertDetailResponse;
-import com.mindgoal.domain.expert.dto.ExpertResponse;
+import com.mindgoal.domain.expert.dto.*;
 import com.mindgoal.domain.expert.entity.Expert;
 import com.mindgoal.domain.expert.repository.ExpertRepository;
 import com.mindgoal.domain.expert.service.ExpertService;
@@ -247,5 +245,121 @@ class ExpertServiceTest {
                 .teachingMethod("1:1 맞춤형 기술 훈련")
                 .pricePerHour(50000)
                 .build();
+    }
+    @DisplayName("전문가 정보 수정 성공")
+    @Test
+    void updateExpert_Success() {
+        // given
+        User user = createUser("test@example.com", "testUser");
+        setSecurityContext(user.getEmail());
+        Expert expert = createExpert(user.getId());
+
+        ExpertUpdateRequest request = ExpertUpdateRequest.builder()
+                .specialty("수정된 전문 분야")
+                .position("수정된 포지션")
+                .description("수정된 설명")
+                .careerHistory("수정된 경력")
+                .teachingMethod("수정된 교육방식")
+                .pricePerHour(60000)
+                .youtubeUrl("https://youtube.com/updated")
+                .instagramUrl("https://instagram.com/updated")
+                .build();
+
+        // when
+        ExpertUpdateResponse response = expertService.updateExpert(expert.getId(), request);
+
+        // then
+        Expert updatedExpert = expertRepository.findById(expert.getId())
+                .orElseThrow(() -> new AssertionError("Expert should exist"));
+
+        assertThat(updatedExpert)
+                .satisfies(e -> {
+                    assertThat(e.getSpeciality()).isEqualTo("수정된 전문 분야");
+                    assertThat(e.getPosition()).isEqualTo("수정된 포지션");
+                    assertThat(e.getDescription()).isEqualTo("수정된 설명");
+                    assertThat(e.getCareerHistory()).isEqualTo("수정된 경력");
+                    assertThat(e.getTeachingMethod()).isEqualTo("수정된 교육방식");
+                    assertThat(e.getPricePerHour()).isEqualTo(60000);
+                    assertThat(e.getYoutubeUrl()).isEqualTo("https://youtube.com/updated");
+                    assertThat(e.getInstagramUrl()).isEqualTo("https://instagram.com/updated");
+                });
+
+        assertThat(response)
+                .satisfies(r -> {
+                    assertThat(r.getId()).isEqualTo(expert.getId());
+                    assertThat(r.getUpdatedAt()).isNotNull();
+                });
+    }
+
+    @DisplayName("전문가 정보 부분 수정 성공")
+    @Test
+    void updateExpert_PartialUpdate_Success() {
+        // given
+        User user = createUser("test@example.com", "testUser");
+        setSecurityContext(user.getEmail());
+        Expert expert = createExpert(user.getId());
+
+        ExpertUpdateRequest request = ExpertUpdateRequest.builder()
+                .specialty("수정된 전문 분야")
+                .pricePerHour(60000)
+                .build();
+
+        // when
+        ExpertUpdateResponse response = expertService.updateExpert(expert.getId(), request);
+
+        // then
+        Expert updatedExpert = expertRepository.findById(expert.getId())
+                .orElseThrow(() -> new AssertionError("Expert should exist"));
+
+        assertThat(updatedExpert)
+                .satisfies(e -> {
+                    // 수정된 필드
+                    assertThat(e.getSpeciality()).isEqualTo("수정된 전문 분야");
+                    assertThat(e.getPricePerHour()).isEqualTo(60000);
+
+                    // 기존 값이 유지되어야 하는 필드들
+                    assertThat(e.getPosition()).isEqualTo("공격수");
+                    assertThat(e.getDescription()).isEqualTo("전문가 설명");
+                    assertThat(e.getCareerHistory()).isEqualTo("경력 사항");
+                    assertThat(e.getTeachingMethod()).isEqualTo("교육 방식");
+                });
+
+        assertThat(response.getId()).isEqualTo(expert.getId());
+    }
+
+    @DisplayName("존재하지 않는 전문가 정보 수정 실패")
+    @Test
+    void updateExpert_NotFound_ThrowsException() {
+        // given
+        User user = createUser("test@example.com", "testUser");
+        setSecurityContext(user.getEmail());
+        Long nonExistentExpertId = 999L;
+
+        ExpertUpdateRequest request = ExpertUpdateRequest.builder()
+                .specialty("수정된 전문 분야")
+                .build();
+
+        // when & then
+        assertThrows(CustomException.class,
+                () -> expertService.updateExpert(nonExistentExpertId, request));
+    }
+
+    @DisplayName("권한 없는 사용자의 전문가 정보 수정 실패")
+    @Test
+    void updateExpert_UnauthorizedAccess_ThrowsException() {
+        // given
+        User owner = createUser("owner@example.com", "owner");
+        User other = createUser("other@example.com", "other");
+        Expert expert = createExpert(owner.getId());
+
+        setSecurityContext(other.getEmail());
+
+        ExpertUpdateRequest request = ExpertUpdateRequest.builder()
+                .specialty("수정된 전문 분야")
+                .build();
+
+        // when & then
+        assertThrows(CustomException.class,
+                () -> expertService.updateExpert(expert.getId(), request));
     }
 }


### PR DESCRIPTION
# Pull Request

## 💡 PR 요약
전문가 정보 수정 API를 구현했습니다. 전문가는 자신의 프로필 정보를 부분적으로 수정할 수 있으며, 수정된 정보는 즉시 반영됩니다.

## 🔍 주요 변경사항
1. 전문가 정보 수정 API 엔드포인트 추가
   - PUT `/api/v1/expert/{expertId}` 엔드포인트 구현
   - 요청/응답 DTO 구현
   - 권한 검증 로직 추가

2. Expert 엔티티 기능 추가
   - 부분 업데이트를 지원하는 update 메서드 구현
   - 수정 가능한 필드: specialty, position, description 등

3. 응답 상태 코드 추가
   - EXPERT_UPDATE_SUCCESS (200)
   - UNAUTHORIZED_ACCESS (403)

4. 테스트 케이스 추가
   - 전체/부분 수정 테스트
   - 예외 케이스 테스트 (권한 없음, 존재하지 않는 전문가)

## 🔗 연관된 이슈
close #N

## ✅ 체크리스트
- [x] 테스트 코드를 작성하였나요?
  - 성공 케이스 (전체/부분 수정)
  - 실패 케이스 (권한 없음, 존재하지 않는 전문가)
- [x] 관련 문서를 업데이트하였나요?
  - BaseResponseStatus에 새로운 상태 코드 추가
- [ ] Breaking Change가 있나요?
  - 없음
- [x] 코드 포맷팅과 린트 검사를 완료하였나요?
  - IntelliJ 포맷터 적용 완료

## 🙏 리뷰어 참고사항


## 📋 추가 컨텍스트
