### PR TITLE
[Mind 9-1] 전문가 상세 조회 기능 관련 피드백 반영

### DIFF
--- a/src/main/java/com/mindgoal/domain/expert/controller/ExpertController.java
+++ b/src/main/java/com/mindgoal/domain/expert/controller/ExpertController.java
@@ -56,7 +56,7 @@ public class ExpertController {
         return ResponseEntity.ok(BaseResponse.success(response, "전문가 목록 조회 성공"));
     }
 
-    @GetMapping("/{Id}")
+    @GetMapping("/{expertId}")
     public ResponseEntity<BaseResponse<ExpertDetailResponse>> getExpertDetail(
             @PathVariable Long expertId) {
         ExpertDetailResponse response = expertService.getExpertDetail(expertId);

--- a/src/main/java/com/mindgoal/domain/expert/dto/ExpertDetailResponse.java
+++ b/src/main/java/com/mindgoal/domain/expert/dto/ExpertDetailResponse.java
@@ -43,7 +43,7 @@ public class ExpertDetailResponse {
         private String instagram;
     }
 
-    public static ExpertDetailResponse from(Expert expert, String userName) {
+    public static ExpertDetailResponse of(Expert expert, String userName) {
         return ExpertDetailResponse.builder()
                 .id(expert.getId())
                 .userId(expert.getUserId())

--- a/src/main/java/com/mindgoal/domain/expert/repository/ExpertRepository.java
+++ b/src/main/java/com/mindgoal/domain/expert/repository/ExpertRepository.java
@@ -1,10 +1,17 @@
 package com.mindgoal.domain.expert.repository;
 
 import com.mindgoal.domain.expert.entity.Expert;
+import com.mindgoal.common.BaseResponseStatus;
+import com.mindgoal.exception.CustomException;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ExpertRepository extends JpaRepository<Expert, Long>, ExpertRepositoryCustom {
     boolean existsByUserId(Long userId);
+
+    default Expert findExpertByIdOrThrow(Long id) {
+        return findById(id)
+                .orElseThrow(() -> new CustomException(BaseResponseStatus.EXPERT_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/mindgoal/domain/expert/repository/ExpertRepository.java
+++ b/src/main/java/com/mindgoal/domain/expert/repository/ExpertRepository.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Repository;
 public interface ExpertRepository extends JpaRepository<Expert, Long>, ExpertRepositoryCustom {
     boolean existsByUserId(Long userId);
 
-    default Expert findExpertByIdOrThrow(Long id) {
+    default Expert findExpertById(Long id) {
         return findById(id)
                 .orElseThrow(() -> new CustomException(BaseResponseStatus.EXPERT_NOT_FOUND));
     }

--- a/src/main/java/com/mindgoal/domain/expert/service/ExpertService.java
+++ b/src/main/java/com/mindgoal/domain/expert/service/ExpertService.java
@@ -34,8 +34,7 @@ public class ExpertService {
 
     @Transactional(readOnly = true)
     public Expert getExpert(Long id) {
-        return expertRepository.findById(id)
-                .orElseThrow(() -> new CustomException(BaseResponseStatus.EXPERT_NOT_FOUND));
+        return expertRepository.findExpertByIdOrThrow(id);
     }
 
     @Transactional(readOnly = true)
@@ -63,19 +62,16 @@ public class ExpertService {
 
     @Transactional(readOnly = true)
     public ExpertDetailResponse getExpertDetail(Long expertId) {
-        Expert expert = expertRepository.findById(expertId)
-                .orElseThrow(() -> new CustomException(BaseResponseStatus.EXPERT_NOT_FOUND));
-
+        Expert expert = expertRepository.findExpertByIdOrThrow(expertId);
         User user = userService.getUser(expert.getUserId());
-        return ExpertDetailResponse.from(expert, user.getName());
+        return ExpertDetailResponse.of(expert, user.getName());
     }
 
     @Transactional
     public ExpertUpdateResponse updateExpert(Long expertId, ExpertUpdateRequest request) {
-        Expert expert = getExpert(expertId);
+        Expert expert = expertRepository.findExpertByIdOrThrow(expertId);
         User currentUser = userService.getCurrentUser();
 
-        // Verify if the current user owns this expert profile
         if (!expert.getUserId().equals(currentUser.getId())) {
             throw new CustomException(BaseResponseStatus.UNAUTHORIZED_ACCESS);
         }

--- a/src/main/java/com/mindgoal/domain/expert/service/ExpertService.java
+++ b/src/main/java/com/mindgoal/domain/expert/service/ExpertService.java
@@ -34,7 +34,7 @@ public class ExpertService {
 
     @Transactional(readOnly = true)
     public Expert getExpert(Long id) {
-        return expertRepository.findExpertByIdOrThrow(id);
+        return expertRepository.findExpertById(id);
     }
 
     @Transactional(readOnly = true)
@@ -62,14 +62,14 @@ public class ExpertService {
 
     @Transactional(readOnly = true)
     public ExpertDetailResponse getExpertDetail(Long expertId) {
-        Expert expert = expertRepository.findExpertByIdOrThrow(expertId);
+        Expert expert = expertRepository.findExpertById(expertId);
         User user = userService.getUser(expert.getUserId());
         return ExpertDetailResponse.of(expert, user.getName());
     }
 
     @Transactional
     public ExpertUpdateResponse updateExpert(Long expertId, ExpertUpdateRequest request) {
-        Expert expert = expertRepository.findExpertByIdOrThrow(expertId);
+        Expert expert = expertRepository.findExpertById(expertId);
         User currentUser = userService.getCurrentUser();
 
         if (!expert.getUserId().equals(currentUser.getId())) {


### PR DESCRIPTION
# [Mind-9] 전문가 상세 조회 기능 구현

## 💡 PR 요약
기존 피드백을 반영하여 PR을 올립니다!

## 🔍 주요 변경사항
- 전문가 상세 조회 API 엔드포인트 수정 (`GET /api/v1/experts/{expertId}`)
- Expert 관련 DTO의 정적 팩토리 메서드 네이밍 컨벤션 통일

## 🔗 연관된 이슈
- #9: 전문가 상세 조회 기능 구현

## ✅ 체크리스트
- [x] 테스트 코드를 작성하였나요?
  - ExpertServiceTest에 상세 조회 관련 테스트 케이스 추가
- [x] 관련 문서를 업데이트하였나요?
  - Swagger 문서 업데이트 완료
- [ ] Breaking Change가 있나요?
- [x] 코드 포맷팅과 린트 검사를 완료하였나요?

## 🙏 리뷰어 참고사항


## 📋 추가 컨텍스트
