### PR TITLE
카카오로그인기능 수정, 채팅메시지 생성기능 구현(미 테스트)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,9 @@ dependencies {
 
 	// Lombok for Tests
 	testAnnotationProcessor 'org.projectlombok:lombok'
+
+	// open feign
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.1.0'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.3.0'
+	id 'org.springframework.boot' version '3.2.2'
 	id 'io.spring.dependency-management' version '1.1.6'
 	id 'org.asciidoctor.jvm.convert' version '3.3.2'
 }
@@ -32,6 +32,7 @@ dependencies {
 	// Web, JPA, Validation, Cache, Actuator, Monitoring
 	implementation 'me.paulschwarz:spring-dotenv:4.0.0'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/main/java/com/mindgoal/MindGoalBackendApplication.java
+++ b/src/main/java/com/mindgoal/MindGoalBackendApplication.java
@@ -2,10 +2,12 @@ package com.mindgoal;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableFeignClients
 public class MindGoalBackendApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/mindgoal/common/BaseResponseStatus.java
+++ b/src/main/java/com/mindgoal/common/BaseResponseStatus.java
@@ -18,6 +18,9 @@ public enum BaseResponseStatus {
     METHOD_NOT_ALLOWED(false, 405, "허용되지 않은 메서드입니다"),
     EXPERT_ALREADY_EXISTS(false, 409, "이미 등록된 전문가입니다"),
     EXPERT_NOT_FOUND(false, 404, "전문가를 찾을 수 없습니다"),
+    EXPIRED_ACCESS_TOKEN(false, 404, "만료된 토큰입니다."),
+    UNSUPPORTED(false, 404, "지원하지 않는 토큰입니다."),
+    TOKEN_NOT_FOUND(false, 404, "존재하지 않는 토큰입니다."),
 
     // 500번대: Server 오류
     INTERNAL_SERVER_ERROR(false, 500, "서버 내부 오류가 발생했습니다"),

--- a/src/main/java/com/mindgoal/config/SecurityConfig.java
+++ b/src/main/java/com/mindgoal/config/SecurityConfig.java
@@ -1,15 +1,22 @@
 package com.mindgoal.config;
 
+import com.mindgoal.config.handler.JwtAccessDeniedHandler;
+import com.mindgoal.config.handler.JwtAuthenticationEntryPoint;
 import com.mindgoal.config.jwt.JwtAuthenticationFilter;
+import com.mindgoal.config.jwt.JwtExceptionFilter;
+import com.mindgoal.config.jwt.JwtTokenProvider;
 import java.util.Arrays;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -27,58 +34,41 @@ public class SecurityConfig {
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
-    public static final String API_V_1 = "/"; //"/api/v1/";
-    private static final List<String> ORIGIN_PATTERN = List.of("*");
-    private static final String CORS_CONFIGURATION_PATTERN = "/**";
 
-    private static final List<String> ALLOWED_HEADERS = Arrays.asList("Origin", "Content-Type", "Accept", "Authorization", "X-Requested-With");
-    private static final List<String> ALLOWED_METHODS = Arrays.asList("GET", "POST", "PUT", "DELETE");
+    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    private final JwtExceptionFilter jwtExceptionFilter;
 
-    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final String[] COMMON_WHITE_LIST = new String[]{"/favicon.ico/**", "/login/**", "/error/**",
+            "/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html"};
 
     @Bean
-    public SecurityFilterChain filterChain(final HttpSecurity http) throws Exception {
-        return http.authorizeHttpRequests(
-                        authorizationManagerRequestMatcherRegistry -> authorizationManagerRequestMatcherRegistry
-                                .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**").permitAll() // Swagger 관련 경로 허용
-                                .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
-                                .requestMatchers(API_V_1 + "oauth/login").permitAll()
-                                .requestMatchers(API_V_1 + "oauth/logout").authenticated()
-                                .requestMatchers(API_V_1 + "chat/**").permitAll()
-                                .requestMatchers(API_V_1 + "matching/**").permitAll()
-                                .requestMatchers(API_V_1 + "payment/*/wishes").authenticated()
-                                .requestMatchers(API_V_1 + "schedule/**").permitAll()
-                                .requestMatchers(API_V_1 + "test/**").permitAll()
-                                .requestMatchers(API_V_1 + "user/**").authenticated()
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .headers(headerConfig -> headerConfig.frameOptions(FrameOptionsConfig::disable))
+                .exceptionHandling(exceptionConfig ->
+                        exceptionConfig
+                                .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                                .accessDeniedHandler(jwtAccessDeniedHandler)
+                )
+                .authorizeHttpRequests(authorizeRequests ->
+                        authorizeRequests
+                                .requestMatchers(COMMON_WHITE_LIST).permitAll()
                                 .anyRequest().authenticated()
                 )
-                .addFilterBefore(
-                        jwtAuthenticationFilter,
-                        UsernamePasswordAuthenticationFilter.class
-                )
-                .headers(header -> header.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable).disable())
-                .httpBasic(AbstractHttpConfigurer::disable)
-                .csrf(AbstractHttpConfigurer::disable)
-                .cors(httpSecurityCorsConfigurer -> corsConfigurationSource())
-//                .exceptionHandling( //todo 예외 핸들링 처리 토의 필요
-//                        httpSecurityExceptionHandlingConfigurer -> httpSecurityExceptionHandlingConfigurer
-//                                .authenticationEntryPoint(customAuthenticationEntryPoint)
-//                                .accessDeniedHandler(authenticationAccessDeniedHandler)
-//                )
-                .build();
-    }
-
-    @Bean
-    public CorsConfigurationSource corsConfigurationSource() {
-        final CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOriginPatterns(ORIGIN_PATTERN);
-        configuration.setAllowedHeaders(ALLOWED_HEADERS);
-        configuration.setAllowedMethods(ALLOWED_METHODS);
-        configuration.setAllowCredentials(true);
-
-        final UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration(CORS_CONFIGURATION_PATTERN, configuration);
-
-        return source;
+                .cors(Customizer.withDefaults())
+                .sessionManagement(configurer -> configurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
+                        UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class)
+                .logout(logout -> logout.logoutSuccessUrl("/"))
+                .oauth2Login(oauth2 ->
+                        oauth2.redirectionEndpoint(info -> info.baseUri("/oauth2/code/*"))
+                );
+        return http.build();
     }
 }

--- a/src/main/java/com/mindgoal/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/mindgoal/config/jwt/JwtAuthenticationFilter.java
@@ -1,13 +1,14 @@
 package com.mindgoal.config.jwt;
 
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.JwtException;
+import static com.mindgoal.common.BaseResponseStatus.TOKEN_NOT_FOUND;
+
+import com.mindgoal.exception.CustomException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -15,59 +16,48 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-@Component
 @RequiredArgsConstructor
+@Slf4j
+@Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private static final String HEADER_AUTHORIZATION = "Authorization";
+    private static final String PREFIX_TOKEN = "Bearer ";
 
     private final JwtTokenProvider jwtTokenProvider;
 
-    private static final String AUTHORIZATION_HEADER = "Authorization";
-    private static final String BEARER_PREFIX = "Bearer ";
-
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        try {
-            String jwtToken = parseJwt(request);
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
 
-            if (jwtToken != null) {
-                if (jwtTokenProvider.validateToken(jwtToken)) {
-                    processValidToken(jwtToken);
-                } else {
-                    processExpiredToken(jwtToken, response);
-                }
+        String requestUri = request.getRequestURI();
+        if (requestUri.matches("^\\/login(?:\\/.*)?$") || requestUri.matches("^\\/oauth2(?:\\/.*)?$")
+                || requestUri.matches("^\\/favicon.ico(?:\\/.*)?$")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = resolveToken(request);
+
+        if (token != null) {
+            if (!jwtTokenProvider.isValidToken(token)) {
+                throw new CustomException(TOKEN_NOT_FOUND);
             }
-        } catch (ExpiredJwtException e) {
-            response.sendError(HttpStatus.UNAUTHORIZED.value(), "토큰이 만료되었습니다.");
-        } catch (JwtException e) {
-            response.sendError(HttpStatus.UNAUTHORIZED.value(), "유효한 토큰이 아닙니다.");
-        } catch (Exception e) {
-            response.sendError(HttpStatus.INTERNAL_SERVER_ERROR.value(), "서버 오류가 발생했습니다.");
+            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+
+            // 여기서 인증 객체를 출력해 확인
+            log.info("Authentication Object: {}", authentication);
+            log.info("Principal Details: {}", authentication.getPrincipal());
         }
 
         filterChain.doFilter(request, response);
     }
 
-    private String parseJwt(HttpServletRequest request) {
-        String headerAuth = request.getHeader(AUTHORIZATION_HEADER);
-        if (StringUtils.hasText(headerAuth) && headerAuth.startsWith(BEARER_PREFIX)) {
-            return headerAuth.substring(BEARER_PREFIX.length());
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(HEADER_AUTHORIZATION);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(PREFIX_TOKEN)) {
+            return bearerToken.substring(PREFIX_TOKEN.length());
         }
         return null;
-    }
-
-    // 토큰 처리 로직 분리
-    private void processValidToken(String token) {
-        Authentication auth = jwtTokenProvider.getAuthentication(token);
-        SecurityContextHolder.getContext().setAuthentication(auth);
-    }
-
-    // 만료 토큰 검증후 재발급
-    private void processExpiredToken(String oldToken, HttpServletResponse response) {
-        String username = jwtTokenProvider.getUserName(oldToken);
-        JwTokenDto newToken = jwtTokenProvider.generateToken(username);
-        response.setHeader(AUTHORIZATION_HEADER, BEARER_PREFIX + newToken.getAccessToken());
-
-        Authentication auth = jwtTokenProvider.getAuthentication(newToken.getAccessToken());
-        SecurityContextHolder.getContext().setAuthentication(auth);
     }
 }

--- a/src/main/java/com/mindgoal/config/jwt/JwtExceptionFilter.java
+++ b/src/main/java/com/mindgoal/config/jwt/JwtExceptionFilter.java
@@ -1,0 +1,39 @@
+package com.mindgoal.config.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+@Component
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (JwtException e) {
+            Map<String, String> map = new HashMap<>();
+            map.put("code", e.getClass().getSimpleName());
+            map.put("message", e.getMessage());
+
+            StackTraceElement element = e.getStackTrace()[0];
+
+            response.setContentType("application/json;charset=UTF-8");
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            response.getWriter().print(objectMapper.writeValueAsString(map));
+        }
+    }
+}

--- a/src/main/java/com/mindgoal/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/mindgoal/config/jwt/JwtTokenProvider.java
@@ -1,91 +1,132 @@
 package com.mindgoal.config.jwt;
 
+import static com.mindgoal.common.BaseResponseStatus.EXPIRED_ACCESS_TOKEN;
+import static com.mindgoal.common.BaseResponseStatus.UNSUPPORTED;
+import static com.mindgoal.common.BaseResponseStatus.TOKEN_NOT_FOUND;
+
+import com.mindgoal.domain.user.dto.TokenDto;
+import com.mindgoal.domain.user.entity.auth.PrincipalDetails;
+import com.mindgoal.domain.user.service.auth.PrincipalDetailService;
+import com.mindgoal.exception.CustomException;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.SignatureAlgorithm;
-import io.jsonwebtoken.io.Decoders;
-import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.UnsupportedJwtException;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
 import org.springframework.security.core.Authentication;
-import java.security.Key;
-import java.util.Collections;
 import java.util.Date;
 
 
 @Component
+@RequiredArgsConstructor
 public class JwtTokenProvider {
 
-    private final Key key;
-    private final long VALID_MILISECOND = 1000L * 60 * 60; // 1시간
-    private static final long REFRESH_TOKEN_VALIDITY = 1000L * 60 * 60 * 24; // 24시간
-    private static final String BEARER_PREFIX = "Bearer ";
+    @Value("${custom.jwt.secret-key}")
+    private String SECRET_KEY;
+    private static final Long ACCESS_TOKEN_EXPIRE_COUNT = 3 * 60 * 60 * 1000L;
+    private static final Long REFRESH_TOKEN_EXPIRE_COUNT = 7 * 24 * 60 * 60 * 1000L;
 
-    public JwtTokenProvider(@Value("${spring.security.jwt.secret}") String secretkey) {
-        byte[] keyBytes = Decoders.BASE64.decode(secretkey);
-        this.key = Keys.hmacShaKeyFor(keyBytes);
+    private final PrincipalDetailService principalDetailService;
+
+    public TokenDto createAccessToken(String email) {
+        Claims claims = Jwts.claims().setSubject(email); // JWT payload 에 저장되는 정보단위, 보통 여기서 user를 식별하는 값을 넣는다.
+        Date now = new Date();
+
+        String accessToken = Jwts.builder()
+                .setClaims(claims) // 정보 저장
+                .setIssuedAt(now) // 토큰 발행 시간 정보
+                .setExpiration(new Date(now.getTime() + ACCESS_TOKEN_EXPIRE_COUNT)) // 토큰 만료 시간
+                // 사용할 암호화 알고리즘과 signature 에 들어갈 secret값 세팅
+                .signWith(SignatureAlgorithm.HS256, SECRET_KEY)
+                .compact();
+
+        return TokenDto.builder()
+                .accessToken(accessToken)
+                .key(email)
+                .build();
     }
 
-    public String getUserName(String jwtToken){
-        return Jwts.parserBuilder()
-                .setSigningKey(key)
-                .build()
-                .parseClaimsJws(jwtToken)
-                .getBody()
-                .getSubject();
+    public TokenDto createRefreshToken(String email) {
+        Claims claims = Jwts.claims().setSubject(email);
+        Date now = new Date();
+
+        String refreshToken = Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + REFRESH_TOKEN_EXPIRE_COUNT))
+                .signWith(SignatureAlgorithm.HS256, SECRET_KEY)
+                .compact();
+
+        return TokenDto.builder()
+                .refreshToken(refreshToken)
+                .key(email)
+                .build();
     }
 
-    public boolean validateToken(String jwtToken){
-        try{
-            Jws<Claims> claims = Jwts.parserBuilder()
-                    .setSigningKey(key)
+    public boolean isExpired(String token) {
+        return new Date(Long.parseLong(decodeToken(token).get("exp")) * 1000).before(new Date());
+    }
+
+    public Authentication getAuthentication(String token) {
+
+        PrincipalDetails principalDetails = principalDetailService.loadUserByUsername(getPayload(token));
+        return new UsernamePasswordAuthenticationToken(principalDetails, "", principalDetails.getAuthorities());
+    }
+
+    public boolean isValidToken(String token) {
+        try {
+            Jws<Claims> claimsJws = Jwts.parserBuilder()
+                    .setSigningKey(SECRET_KEY)
                     .build()
-                    .parseClaimsJws(jwtToken);
-            return !claims.getBody().getExpiration().before(new Date());
-        }catch (Exception e){
-            return false;
+                    .parseClaimsJws(token);
+
+            return !claimsJws.getBody().getExpiration().before(new Date());
+        } catch (ExpiredJwtException e) {
+            throw new CustomException(EXPIRED_ACCESS_TOKEN);
+        } catch (UnsupportedJwtException e) {
+            throw new CustomException(UNSUPPORTED);
+        } catch (MalformedJwtException | IllegalArgumentException e) {
+            throw new CustomException(TOKEN_NOT_FOUND);
         }
     }
 
-    public Authentication getAuthentication(String jwtToken) {
-
-        String email = getUserName(jwtToken);
-
-        SimpleGrantedAuthority authority = new SimpleGrantedAuthority("ROLE_USER");
-
-        return new UsernamePasswordAuthenticationToken(
-                email,
-                null,
-                Collections.singleton(authority)
-        );
-    }
-    private Claims createClaims(String userName){
-        Claims claims = Jwts.claims();
-        claims.setSubject(userName);
-        claims.setIssuedAt(new Date());
-
-        return claims;
+    public String getPayload(String token) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(SECRET_KEY)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody().getSubject();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims().getSubject();
+        }
     }
 
-    public JwTokenDto generateToken(String userName){
-        Claims claims = createClaims(userName);
-        long now = (new Date()).getTime();
-        Date accessTokenExpiresIn = new Date(now + VALID_MILISECOND);
+    private Map<String, String> decodeToken(String token) {
+        String[] split = token.split("\\.");
 
-        String accessToken = Jwts.builder()
-                .setClaims(claims) // 발행 유저 정보 저장
-                .setExpiration(accessTokenExpiresIn)
-                .signWith(key, SignatureAlgorithm.HS256)
-                .compact();
+        Base64.Decoder decoder = Base64.getUrlDecoder();
 
-        String refreshToken = Jwts.builder()
-                .setExpiration(new Date(now + REFRESH_TOKEN_VALIDITY))
-                .signWith(key, SignatureAlgorithm.HS256)
-                .compact();
+        String payload = new String(decoder.decode(split[1]));
+        payload = payload.replaceAll("[{}\"]", "");
 
-        return new JwTokenDto(BEARER_PREFIX, accessToken, refreshToken, accessTokenExpiresIn);
+        Map<String, String> map = new HashMap<>();
+
+        String[] contents = payload.split(",");
+        for (String content : contents) {
+            String[] c = content.split(":");
+            map.put(c[0], c[1]);
+        }
+
+        return map;
     }
 }

--- a/src/main/java/com/mindgoal/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/mindgoal/domain/chat/controller/ChatController.java
@@ -8,9 +8,10 @@ import com.mindgoal.domain.user.entity.auth.PrincipalDetails;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/chat")
 @RequiredArgsConstructor
 public class ChatController {
+    private final SimpMessagingTemplate messagingTemplate;
     private final ChatService chatService;
 
     @GetMapping("/room-list")
@@ -27,10 +29,10 @@ public class ChatController {
         return ResponseEntity.ok(chatRoomsResponse);
     }
 
-    @PostMapping("/message")
-    public ResponseEntity<ChatMessageResponse> createChatMessage(@RequestBody ChatMessageRequest chatMessageRequest,
+    @MessageMapping("/message")
+    public void createChatMessage(@RequestBody ChatMessageRequest chatMessageRequest,
                                                                  @AuthenticationPrincipal PrincipalDetails user) {
         final ChatMessageResponse chatMessageResponse = chatService.sendMessage(user.getId(), chatMessageRequest);
-        return ResponseEntity.ok(chatMessageResponse);
+        messagingTemplate.convertAndSend("/sub/chat" + chatMessageResponse.chatRoomId(), chatMessageResponse);
     }
 }

--- a/src/main/java/com/mindgoal/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/mindgoal/domain/chat/controller/ChatController.java
@@ -10,7 +10,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/src/main/java/com/mindgoal/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/mindgoal/domain/chat/controller/ChatController.java
@@ -1,6 +1,7 @@
 package com.mindgoal.domain.chat.controller;
 
-import com.mindgoal.domain.chat.dto.ChatRoomRequest;
+import com.mindgoal.domain.chat.dto.ChatMessageRequest;
+import com.mindgoal.domain.chat.dto.ChatMessageResponse;
 import com.mindgoal.domain.chat.dto.ChatRoomResponse;
 import com.mindgoal.domain.chat.service.ChatService;
 import com.mindgoal.domain.user.entity.auth.PrincipalDetails;
@@ -9,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,16 +22,16 @@ import org.springframework.web.bind.annotation.RestController;
 public class ChatController {
     private final ChatService chatService;
 
-    @PostMapping
-    public ResponseEntity<ChatRoomResponse> createChatRoom(@RequestBody ChatRoomRequest chatRoomRequest,
-                                                           @AuthenticationPrincipal PrincipalDetails user) {
-        final ChatRoomResponse chatRoomResponse = chatService.saveChatRoom(chatRoomRequest, user.getId());
-        return ResponseEntity.ok(chatRoomResponse);
-    }
-
     @GetMapping("/room-list")
     public ResponseEntity<List<ChatRoomResponse>> getMyChatRooms(@AuthenticationPrincipal PrincipalDetails user) {
         final List<ChatRoomResponse> chatRoomsResponse = chatService.getMyChatRooms(user.getId());
         return ResponseEntity.ok(chatRoomsResponse);
+    }
+
+    @PostMapping("/message")
+    public ResponseEntity<ChatMessageResponse> createChatMessage(@RequestBody ChatMessageRequest chatMessageRequest,
+                                                                 @AuthenticationPrincipal PrincipalDetails user) {
+        final ChatMessageResponse chatMessageResponse = chatService.sendMessage(user.getId(), chatMessageRequest);
+        return ResponseEntity.ok(chatMessageResponse);
     }
 }

--- a/src/main/java/com/mindgoal/domain/chat/dto/ChatMessageRequest.java
+++ b/src/main/java/com/mindgoal/domain/chat/dto/ChatMessageRequest.java
@@ -1,10 +1,4 @@
 package com.mindgoal.domain.chat.dto;
 
-import lombok.Getter;
-
-@Getter
-public class ChatMessageRequest {
-    private Long chatRoomId;
-    private Long senderId;
-    private String content;
+public record ChatMessageRequest(Long expertId, Long userId, String content) {
 }

--- a/src/main/java/com/mindgoal/domain/chat/dto/ChatMessageResponse.java
+++ b/src/main/java/com/mindgoal/domain/chat/dto/ChatMessageResponse.java
@@ -1,0 +1,11 @@
+package com.mindgoal.domain.chat.dto;
+
+import com.mindgoal.domain.chat.entity.ChatMessage;
+
+public record ChatMessageResponse(Long id, Long userId, Long chatRoomId, String content, int readCount) {
+
+    public static ChatMessageResponse from(final ChatMessage chatMessage) {
+        return new ChatMessageResponse(chatMessage.getId(), chatMessage.getUserId(), chatMessage.getChatRoomId(),
+                chatMessage.getContent(), chatMessage.getReadCount());
+    }
+}

--- a/src/main/java/com/mindgoal/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/com/mindgoal/domain/chat/entity/ChatMessage.java
@@ -17,7 +17,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 public class ChatMessage extends BaseEntity {
-    private final int DEFAULT_READ_COUNT = 2; // 추후 단체 컨설팅 기능이 생긴다면 수정해야하는 로직
+    private final int DEFAULT_READ_COUNT = 1; // 추후 단체 컨설팅 기능이 생긴다면 수정해야하는 로직
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/mindgoal/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/com/mindgoal/domain/chat/entity/ChatMessage.java
@@ -17,13 +17,15 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 public class ChatMessage extends BaseEntity {
+    private final int DEFAULT_READ_COUNT = 2; // 추후 단체 컨설팅 기능이 생긴다면 수정해야하는 로직
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "ID", nullable = false)
     private Long id;
 
     @Column
-    private Long senderId;
+    private Long userId;
 
     @Column
     private Long chatRoomId;
@@ -32,7 +34,14 @@ public class ChatMessage extends BaseEntity {
     private String content;
 
     @Column(name = "READ_COUNT")
-    private boolean readYN;
+    private int readCount;
+
+    public ChatMessage(Long userId, Long chatRoomId, String content) {
+        this.userId = userId;
+        this.chatRoomId = chatRoomId;
+        this.content = content;
+        this.readCount = DEFAULT_READ_COUNT;
+    }
 
     @Override
     public boolean equals(Object object) {

--- a/src/main/java/com/mindgoal/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/mindgoal/domain/chat/repository/ChatRoomRepository.java
@@ -2,12 +2,13 @@ package com.mindgoal.domain.chat.repository;
 
 import com.mindgoal.domain.chat.entity.ChatRoom;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
-    boolean existsByExpertIdAndUserId(Long expertId, Long userId);
-
     List<ChatRoom> findAllByExpertId(Long expertId);
 
     List<ChatRoom> findAllByUserId(Long userId);
+
+    Optional<ChatRoom> findByExpertIdAndUserId(Long expertId, Long userId);
 }

--- a/src/main/java/com/mindgoal/domain/chat/service/ChatService.java
+++ b/src/main/java/com/mindgoal/domain/chat/service/ChatService.java
@@ -1,7 +1,10 @@
 package com.mindgoal.domain.chat.service;
 
+import com.mindgoal.domain.chat.dto.ChatMessageRequest;
+import com.mindgoal.domain.chat.dto.ChatMessageResponse;
 import com.mindgoal.domain.chat.dto.ChatRoomRequest;
 import com.mindgoal.domain.chat.dto.ChatRoomResponse;
+import com.mindgoal.domain.chat.entity.ChatMessage;
 import com.mindgoal.domain.chat.entity.ChatRoom;
 import com.mindgoal.domain.chat.entity.ChatRoomStatus;
 import com.mindgoal.domain.chat.repository.ChatMessageRepository;
@@ -20,22 +23,20 @@ public class ChatService {
     private final ExpertRepository expertRepository;
 
     @Transactional
-    public ChatRoomResponse saveChatRoom(final ChatRoomRequest chatRoomRequest,
-                                         final Long userId) {
-        final ChatRoom chatRoom = createChatRoom(chatRoomRequest, userId);
-        return ChatRoomResponse.from(chatRoom);
+    public ChatMessageResponse sendMessage(final Long userId, final ChatMessageRequest chatMessageRequest) {
+        ChatRoom chatRoom = chatRoomRepository.findByExpertIdAndUserId(chatMessageRequest.expertId(), userId)
+                .orElseGet(() -> {
+                    ChatRoom newChatRoom = createChatRoom(chatMessageRequest, userId);
+                    return chatRoomRepository.save(newChatRoom);
+                });
+
+        ChatMessage chatMessage = new ChatMessage(chatRoom.getId(), userId, chatMessageRequest.content());
+        return ChatMessageResponse.from(chatMessageRepository.save(chatMessage));
     }
 
-    private void validateExisted(final Long expertId, final Long userId) {
-        if (chatRoomRepository.existsByExpertIdAndUserId(expertId, userId)) {
-            throw new IllegalArgumentException("already exist");
-        }
-    }
-
-    private ChatRoom createChatRoom(final ChatRoomRequest chatRoomRequest, final Long userId) {
-        validateExisted(chatRoomRequest.getExpertId(), userId);
+    private ChatRoom createChatRoom(final ChatMessageRequest chatMessageRequest, final Long userId) {
         final ChatRoomStatus chatRoomStatus = ChatRoomStatus.createDefaultStatus();
-        return new ChatRoom(chatRoomRequest.getExpertId(), userId, chatRoomStatus);
+        return new ChatRoom(chatMessageRequest.expertId(), userId, chatRoomStatus);
     }
 
     public List<ChatRoomResponse> getMyChatRooms(final Long userId) {

--- a/src/main/java/com/mindgoal/domain/expert/repository/ExpertRepository.java
+++ b/src/main/java/com/mindgoal/domain/expert/repository/ExpertRepository.java
@@ -14,5 +14,10 @@ public interface ExpertRepository extends JpaRepository<Expert, Long>, ExpertRep
         return findById(id)
                 .orElseThrow(() -> new CustomException(BaseResponseStatus.EXPERT_NOT_FOUND));
     }
+
+    default Expert findExpertByUserId(Long userId) {
+        return findById(userId)
+                .orElseThrow(() -> new CustomException(BaseResponseStatus.EXPERT_NOT_FOUND));
+    }
 }
 

--- a/src/main/java/com/mindgoal/domain/refreshToken/dto/RefreshTokenResponse.java
+++ b/src/main/java/com/mindgoal/domain/refreshToken/dto/RefreshTokenResponse.java
@@ -1,0 +1,11 @@
+package com.mindgoal.domain.refreshToken.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class RefreshTokenResponse {
+    private String registrationId;
+    private String refreshToken;
+}

--- a/src/main/java/com/mindgoal/domain/refreshToken/entity/RefreshToken.java
+++ b/src/main/java/com/mindgoal/domain/refreshToken/entity/RefreshToken.java
@@ -1,0 +1,43 @@
+package com.mindgoal.domain.refreshToken.entity;
+
+import com.mindgoal.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Entity
+@Getter
+@Table(name = "REFRESH_TOKEN_TB")
+@NoArgsConstructor
+@AllArgsConstructor
+public class RefreshToken extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "refresh_token_id", nullable = false)
+    private Long refreshTokenId;
+
+    @Column(name = "refresh_token")
+    private String refreshToken;
+
+    @Column(name = "key_email")
+    private String keyEmail;
+
+    private LocalDateTime expiration;
+
+    public static RefreshToken toEntity(String email, String refreshToken) {
+        return RefreshToken.builder()
+                .keyEmail(email)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/com/mindgoal/domain/refreshToken/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/mindgoal/domain/refreshToken/repository/RefreshTokenRepository.java
@@ -1,0 +1,17 @@
+package com.mindgoal.domain.refreshToken.repository;
+
+import com.mindgoal.domain.refreshToken.entity.RefreshToken;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByRefreshToken(String refreshToken);
+
+    boolean existsByKeyEmail(String email);
+
+    void deleteByKeyEmail(String email);
+
+    Optional<RefreshToken> findByKeyEmail(String email);
+}

--- a/src/main/java/com/mindgoal/domain/refreshToken/service/RefreshTokenService.java
+++ b/src/main/java/com/mindgoal/domain/refreshToken/service/RefreshTokenService.java
@@ -1,0 +1,45 @@
+package com.mindgoal.domain.refreshToken.service;
+
+
+import com.mindgoal.domain.refreshToken.entity.RefreshToken;
+import com.mindgoal.domain.refreshToken.repository.RefreshTokenRepository;
+import com.mindgoal.domain.user.repository.UserRepository;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RefreshTokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public RefreshToken save(final String refreshToken, final String email, final Long expirationMs) {
+        userRepository.findByEmail(email)
+                .orElseThrow(IllegalArgumentException::new);
+
+        // 기존의 만료된 리프레시 토큰 삭제
+        if (refreshTokenRepository.existsByKeyEmail(email)) {
+            refreshTokenRepository.deleteByKeyEmail(email);
+        }
+
+        RefreshToken rt = RefreshToken.builder()
+                .keyEmail(email)
+                .refreshToken(refreshToken)
+                .expiration(LocalDateTime.now().plusSeconds(expirationMs / 1000))
+                .build();
+
+        return refreshTokenRepository.save(rt);
+    }
+
+    @Transactional(readOnly = true)
+    public RefreshToken findByRefreshToken(final String refreshToken) {
+        return refreshTokenRepository.findByRefreshToken(refreshToken)
+                .orElseThrow(IllegalArgumentException::new);
+
+    }
+}

--- a/src/main/java/com/mindgoal/domain/user/controller/AuthController.java
+++ b/src/main/java/com/mindgoal/domain/user/controller/AuthController.java
@@ -1,0 +1,28 @@
+package com.mindgoal.domain.user.controller;
+
+import com.mindgoal.domain.user.dto.JwtResponse;
+import com.mindgoal.domain.user.service.auth.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AuthController {
+    private final AuthService authService;
+
+    @GetMapping("/login/oauth2/code/{registrationId}")
+    public ResponseEntity<JwtResponse> redirect(
+            @PathVariable("registrationId") final String registrationId,
+            @RequestParam("code") final String code,
+            @RequestParam("state") final String state
+    ) {
+
+        JwtResponse jwt = authService.redirect(registrationId, code, state);
+
+        return ResponseEntity.ok(jwt);
+    }
+}

--- a/src/main/java/com/mindgoal/domain/user/controller/UserController.java
+++ b/src/main/java/com/mindgoal/domain/user/controller/UserController.java
@@ -1,11 +1,18 @@
 package com.mindgoal.domain.user.controller;
 
 import com.mindgoal.common.BaseResponse;
+import com.mindgoal.domain.user.dto.JwtResponse;
 import com.mindgoal.domain.user.dto.KakaoLoginRequest;
 import com.mindgoal.domain.user.dto.TokenDto;
 import com.mindgoal.domain.user.dto.UpdateUserRequest;
 import com.mindgoal.domain.user.entity.User;
 import com.mindgoal.domain.user.service.UserService;
+import com.mindgoal.domain.user.service.auth.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -16,12 +23,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class UserController {
     private final UserService userService;
-
-    @PostMapping("/oauth/login")
-    public ResponseEntity<BaseResponse<TokenDto>> kakaoLogin(@RequestBody KakaoLoginRequest request) {
-        TokenDto token = userService.kakaoLogin(request.getCode());
-        return ResponseEntity.ok(BaseResponse.success(token, "카카오 로그인 성공"));
-    }
+    private final AuthService authService;
 
     @PostMapping("/oauth/logout")
     public ResponseEntity<BaseResponse<Void>> logout(HttpServletRequest request) {
@@ -40,10 +42,10 @@ public class UserController {
         User updatedUser = userService.updateUser(request);
         return ResponseEntity.ok(BaseResponse.success(updatedUser, "내 정보 수정 성공"));
     }
-    
+
     @DeleteMapping("/user/me")
     public ResponseEntity<BaseResponse<Void>> withdrawUser() {
         userService.withdrawUser();
         return ResponseEntity.ok(BaseResponse.success(null, "회원 탈퇴 성공"));
-    }  
+    }
 }

--- a/src/main/java/com/mindgoal/domain/user/dto/JwtResponse.java
+++ b/src/main/java/com/mindgoal/domain/user/dto/JwtResponse.java
@@ -1,0 +1,14 @@
+package com.mindgoal.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class JwtResponse {
+    private KakaoUserInfo kakaoUserInfo;
+    private Long userId;
+    private String accessToken;
+    private String refreshToken;
+    private String oauthRefreshToken;
+}

--- a/src/main/java/com/mindgoal/domain/user/dto/KakaoUnlinkResponse.java
+++ b/src/main/java/com/mindgoal/domain/user/dto/KakaoUnlinkResponse.java
@@ -1,0 +1,9 @@
+package com.mindgoal.domain.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public class KakaoUnlinkResponse {
+
+    private Long id;
+}

--- a/src/main/java/com/mindgoal/domain/user/dto/KakaoUserInfo.java
+++ b/src/main/java/com/mindgoal/domain/user/dto/KakaoUserInfo.java
@@ -6,20 +6,27 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class KakaoUserInfo {
-    private Long id;
-    private Properties properties;
-    private KakaoAccount kakao_account;
 
-    @Getter
-    @NoArgsConstructor
-    public static class Properties {
-        private String nickname;
-        private String profile_image;
+    private Long id;
+    private KakaoAccount kakaoAccount;
+
+    public String getEmail() {
+        return kakaoAccount != null ? kakaoAccount.getEmail() : null;
+    }
+
+    public String getName() {
+        return kakaoAccount != null ? kakaoAccount.getProfile().getNickname() : null;
     }
 
     @Getter
-    @NoArgsConstructor
-    public static class KakaoAccount {
+    private static class KakaoAccount {
         private String email;
+        private Profile profile;
+
+        @Getter
+        private static class Profile {
+            private String nickname;
+            private String profileImageUrl;
+        }
     }
 }

--- a/src/main/java/com/mindgoal/domain/user/dto/OauthRefresh.java
+++ b/src/main/java/com/mindgoal/domain/user/dto/OauthRefresh.java
@@ -1,0 +1,21 @@
+package com.mindgoal.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class OauthRefresh {
+
+    private String token_type;
+    private String access_token;
+    private Integer expires_in;
+
+    private String grant_type;
+    private String client_id;
+    private String refresh_token;
+}

--- a/src/main/java/com/mindgoal/domain/user/dto/TokenDto.java
+++ b/src/main/java/com/mindgoal/domain/user/dto/TokenDto.java
@@ -1,12 +1,12 @@
 package com.mindgoal.domain.user.dto;
 
-
-import com.mindgoal.config.jwt.JwTokenDto;
-import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
+@Builder
 @Getter
-@AllArgsConstructor
 public class TokenDto {
-    private JwTokenDto token;
+    private String accessToken;
+    private String refreshToken;
+    private String key;
 }

--- a/src/main/java/com/mindgoal/domain/user/dto/TokenResponse.java
+++ b/src/main/java/com/mindgoal/domain/user/dto/TokenResponse.java
@@ -1,0 +1,20 @@
+package com.mindgoal.domain.user.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class TokenResponse {
+
+    private String tokenType;
+    private String accessToken; // oauth access token
+    private Integer expiresIn; // oauth access token expire time
+    private String refreshToken; // oauth refresh token
+    private Integer refreshTokenExpiresIn; // oauth refresh token expire time
+    private String error;
+    private String errorDescription;
+}

--- a/src/main/java/com/mindgoal/domain/user/dto/UserDeleteResponse.java
+++ b/src/main/java/com/mindgoal/domain/user/dto/UserDeleteResponse.java
@@ -1,0 +1,16 @@
+package com.mindgoal.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserDeleteResponse {
+    private Long id;
+
+    public static UserDeleteResponse from(KakaoUnlinkResponse unlink) {
+        return UserDeleteResponse.builder()
+                .id(unlink.getId())
+                .build();
+    }
+}

--- a/src/main/java/com/mindgoal/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/mindgoal/domain/user/dto/UserResponse.java
@@ -1,0 +1,44 @@
+package com.mindgoal.domain.user.dto;
+
+import com.mindgoal.domain.user.entity.User;
+import jakarta.persistence.Column;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class UserResponse {
+
+    private Long id;
+    private String email;
+    private String name;
+    private String phoneNumber;
+    private String profileImage;
+
+    public static UserResponse from(User user) {
+        return UserResponse.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .name(user.getName())
+                .phoneNumber(user.getPhoneNumber())
+                .profileImage(user.getProfileImage())
+                .build();
+    }
+
+    public static List<UserResponse> from(List<User> users) {
+        return users.stream()
+                .map(UserResponse::from)
+                .toList();
+    }
+
+    public static User toEntity(UserResponse response) {
+        return User.builder()
+                .id(response.getId())
+                .email(response.getEmail())
+                .name(response.getName())
+                .phoneNumber(response.getPhoneNumber())
+                .profileImage(response.getProfileImage())
+                .build();
+    }
+}

--- a/src/main/java/com/mindgoal/domain/user/entity/User.java
+++ b/src/main/java/com/mindgoal/domain/user/entity/User.java
@@ -19,7 +19,7 @@ public class User extends BaseEntity {
     @Column(name = "ID", nullable = false)
     private Long id;
 
-    @Column(name = "EMAIL", nullable = false)
+    @Column(name = "EMAIL")
     private String email;
 
     @Column(name = "NAME")

--- a/src/main/java/com/mindgoal/domain/user/entity/User.java
+++ b/src/main/java/com/mindgoal/domain/user/entity/User.java
@@ -22,9 +22,6 @@ public class User extends BaseEntity {
     @Column(name = "EMAIL", nullable = false)
     private String email;
 
-    @Column(name = "PASSWORD", nullable = false)
-    private String password;
-
     @Column(name = "NAME")
     private String name;
 
@@ -44,11 +41,10 @@ public class User extends BaseEntity {
     private LocalDateTime deletedAt;
 
     @Builder
-    public User(Long id, String email, String password, String name, String phoneNumber,
+    public User(Long id, String email, String name, String phoneNumber,
                 String profileImage, Boolean isAgreePolicy) {
         this.id = id;
         this.email = email;
-        this.password = password;
         this.name = name;
         this.phoneNumber = phoneNumber;
         this.profileImage = profileImage;
@@ -56,9 +52,9 @@ public class User extends BaseEntity {
         this.isDeleted = false;
     }
 
-    public User(String email, String password, String name, String phoneNumber,
-                String profileImage, Boolean isAgreePolicy){
-        this(null, email, password, name, phoneNumber, profileImage, isAgreePolicy);
+    public User(String email, String name, String phoneNumber,
+                String profileImage, Boolean isAgreePolicy) {
+        this(null, email, name, phoneNumber, profileImage, isAgreePolicy);
     }
 
     @Override

--- a/src/main/java/com/mindgoal/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/mindgoal/domain/user/repository/UserRepository.java
@@ -6,6 +6,19 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+
     Optional<User> findByEmailAndIsDeletedFalse(String email);
+
     boolean existsByEmailAndIsDeletedFalse(String email);
+
+    default User findUserById(Long id) {
+        return findById(id)
+                .orElseThrow(() -> new IllegalArgumentException(""));
+    }
+
+    default User findUserByEmail(String email) {
+        return findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException(""));
+    }
 }

--- a/src/main/java/com/mindgoal/domain/user/service/UserService.java
+++ b/src/main/java/com/mindgoal/domain/user/service/UserService.java
@@ -104,7 +104,6 @@ public class UserService {
                 .orElseGet(() -> {
                     return userRepository.save(User.builder()
                             .email(email)
-                            .password(passwordEncoder.encode(UUID.randomUUID().toString()))
                             .name(userInfo.getProperties().getNickname())
                             .profileImage(userInfo.getProperties().getProfile_image())
                             .isAgreePolicy(true)

--- a/src/main/java/com/mindgoal/domain/user/service/UserService.java
+++ b/src/main/java/com/mindgoal/domain/user/service/UserService.java
@@ -1,10 +1,8 @@
 package com.mindgoal.domain.user.service;
 
-import com.fasterxml.jackson.databind.JsonNode;
 
-import com.mindgoal.domain.user.dto.KakaoUserInfo;
-import com.mindgoal.domain.user.dto.TokenDto;
 import com.mindgoal.domain.user.dto.UpdateUserRequest;
+import com.mindgoal.domain.user.dto.UserResponse;
 import com.mindgoal.domain.user.entity.User;
 import com.mindgoal.domain.user.repository.UserRepository;
 import com.mindgoal.config.jwt.JwtTokenProvider;
@@ -12,14 +10,11 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.MediaType;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.reactive.function.client.WebClient;
-import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -29,11 +24,16 @@ public class UserService {
     private final JwtTokenProvider jwtTokenProvider;
     private final PasswordEncoder passwordEncoder;
 
-    @Value("${KAKAO_CLIENT_ID}")
-    private String clientId;
+    @Transactional
+    public UserResponse signUp(final String email, final String name) {
 
-    @Value("${KAKAO_REDIRECT_URI}")
-    private String redirectUri;
+        User user = User.builder()
+                .email(email)
+                .name(name)
+                .build();
+
+        return UserResponse.from(userRepository.save(user));
+    }
 
     @Transactional
     public void logout(HttpServletRequest request) {
@@ -49,66 +49,11 @@ public class UserService {
         // 현재 스레드의 로컬 컨텍스트 정리
         SecurityContextHolder.getContext().setAuthentication(null);
     }
-    @Transactional
-    public TokenDto kakaoLogin(String code) {
-        String accessToken = getKakaoAccessToken(code);
-        KakaoUserInfo userInfo = getKakaoUserInfo(accessToken);
-
-        User user = userRepository.findByEmailAndIsDeletedFalse(userInfo.getKakao_account().getEmail())
-                .orElseGet(() -> createKakaoUser(userInfo));
-        return new TokenDto(jwtTokenProvider.generateToken(user.getEmail()));
-    }
 
     public User getCurrentUser() {
         String email = SecurityContextHolder.getContext().getAuthentication().getName();
         return userRepository.findByEmailAndIsDeletedFalse(email)
                 .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + email));
-    }
-
-    private String getKakaoAccessToken(String code) {
-        WebClient.ResponseSpec response = WebClient.create("https://kauth.kakao.com")
-                .post()
-                .uri(uriBuilder -> uriBuilder
-                        .path("/oauth/token")
-                        .queryParam("grant_type", "authorization_code")
-                        .queryParam("client_id", clientId)
-                        .queryParam("redirect_uri", redirectUri)
-                        .queryParam("code", code)
-                        .build())
-                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .retrieve();
-
-        JsonNode jsonNode = response.bodyToMono(JsonNode.class).block();
-        return jsonNode.get("access_token").asText();
-    }
-
-    private KakaoUserInfo getKakaoUserInfo(String accessToken) {
-        return WebClient.create("https://kapi.kakao.com")
-                .get()
-                .uri("/v2/user/me")
-                .header("Authorization", "Bearer " + accessToken)
-                .retrieve()
-                .bodyToMono(KakaoUserInfo.class)
-                .block();
-    }
-
-    @Transactional
-    public User createKakaoUser(KakaoUserInfo userInfo) {
-        String email = userInfo.getKakao_account().getEmail();
-
-        return userRepository.findByEmailAndIsDeletedFalse(email)
-                .map(existingUser -> {
-                    // 기존 사용자의 kakaoId 업데이트 로직 필요시 추가
-                    return existingUser;
-                })
-                .orElseGet(() -> {
-                    return userRepository.save(User.builder()
-                            .email(email)
-                            .name(userInfo.getProperties().getNickname())
-                            .profileImage(userInfo.getProperties().getProfile_image())
-                            .isAgreePolicy(true)
-                            .build());
-                });
     }
 
     @Transactional

--- a/src/main/java/com/mindgoal/domain/user/service/auth/AuthService.java
+++ b/src/main/java/com/mindgoal/domain/user/service/auth/AuthService.java
@@ -1,0 +1,80 @@
+package com.mindgoal.domain.user.service.auth;
+
+
+import com.mindgoal.config.jwt.JwtTokenProvider;
+import com.mindgoal.domain.refreshToken.entity.RefreshToken;
+import com.mindgoal.domain.refreshToken.repository.RefreshTokenRepository;
+import com.mindgoal.domain.refreshToken.service.RefreshTokenService;
+import com.mindgoal.domain.user.dto.JwtResponse;
+import com.mindgoal.domain.user.dto.KakaoUnlinkResponse;
+import com.mindgoal.domain.user.dto.OauthRefresh;
+import com.mindgoal.domain.user.dto.TokenDto;
+import com.mindgoal.domain.user.dto.UserDeleteResponse;
+import com.mindgoal.domain.user.entity.User;
+import com.mindgoal.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final KakaoRequestService kakaoRequestService;
+    private final RefreshTokenService refreshTokenService;
+    private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Transactional
+    public JwtResponse redirect(final String provider, final String code, final String state) {
+        return kakaoRequestService.redirect(provider, code, state);
+    }
+
+    @Transactional
+    public JwtResponse refreshToken(final String refreshToken) {
+
+        if (jwtTokenProvider.isExpired(refreshToken)) {
+            // refresh token 만료시 재로그인 필요
+            throw new IllegalArgumentException();
+        }
+
+        RefreshToken refreshTokenObj = refreshTokenService.findByRefreshToken(refreshToken);
+
+        User user = userRepository.findUserByEmail(refreshTokenObj.getKeyEmail());
+
+        TokenDto newToken = jwtTokenProvider.createAccessToken(user.getEmail());
+
+        return buildSignInResponse(newToken.getAccessToken(), refreshToken, user.getId());
+    }
+
+    private JwtResponse buildSignInResponse(final String accessToken, final String refreshToken, final Long userId) {
+        return JwtResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .userId(userId)
+                .build();
+    }
+
+    @Transactional
+    public UserDeleteResponse deleteUser(final Long userId, final String oauthRefreshToken) {
+
+        User currentUser = userRepository.findUserById(userId);
+
+        deleteAll(currentUser);
+
+        OauthRefresh dto = kakaoRequestService.refresh(oauthRefreshToken);
+
+        KakaoUnlinkResponse unlink = kakaoRequestService.unLink(dto.getAccess_token());
+
+        return UserDeleteResponse.from(unlink);
+    }
+
+    // 연관키로 묶여 있음
+    private void deleteAll(final User currentUser) {
+        refreshTokenRepository.deleteByKeyEmail(currentUser.getEmail());
+        userRepository.delete(currentUser);
+    }
+
+}
+

--- a/src/main/java/com/mindgoal/domain/user/service/auth/KakaoRequestService.java
+++ b/src/main/java/com/mindgoal/domain/user/service/auth/KakaoRequestService.java
@@ -1,0 +1,110 @@
+package com.mindgoal.domain.user.service.auth;
+
+
+import com.mindgoal.config.jwt.JwtTokenProvider;
+import com.mindgoal.domain.refreshToken.entity.RefreshToken;
+import com.mindgoal.domain.refreshToken.repository.RefreshTokenRepository;
+import com.mindgoal.domain.user.dto.JwtResponse;
+import com.mindgoal.domain.user.dto.KakaoUnlinkResponse;
+import com.mindgoal.domain.user.dto.KakaoUserInfo;
+import com.mindgoal.domain.user.dto.OauthRefresh;
+import com.mindgoal.domain.user.dto.TokenDto;
+import com.mindgoal.domain.user.dto.TokenResponse;
+import com.mindgoal.domain.user.dto.UserResponse;
+import com.mindgoal.domain.user.entity.User;
+import com.mindgoal.domain.user.repository.UserRepository;
+import com.mindgoal.domain.user.service.UserService;
+import com.mindgoal.domain.user.service.feign.KakaoAuthClient;
+import com.mindgoal.domain.user.service.feign.KakaoInfoClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoRequestService implements RequestService {
+
+    private final UserService userService;
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final KakaoAuthClient kakaoAuthClient;
+    private final KakaoInfoClient kakaoInfoClient;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.authorization-grant-type}")
+    private String GRANT_TYPE;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+    private String CLIENT_ID;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
+    private String REDIRECT_URI;
+
+    @Value("${spring.security.oauth2.client.provider.kakao.token_uri}")
+    private String TOKEN_URI;
+
+    @Override
+    public JwtResponse redirect(final String provider, final String code, final String state) {
+        // 카카오에서 넘겨준 엑세스 토큰
+        TokenResponse tokenResponse = getToken(code);
+        System.out.println(tokenResponse);
+        // 카카오에서 넘겨준 유저 정보
+        KakaoUserInfo kakaoUserInfo = getUserInfo(tokenResponse.getAccessToken());
+
+        User user = userRepository.findByEmail(kakaoUserInfo.getEmail()).orElse(null);
+
+        // 회원 가입이 되어있는 경우
+        TokenDto newToken_AccessToken = jwtTokenProvider.createAccessToken(kakaoUserInfo.getEmail());
+        TokenDto newToken_RefreshToken = jwtTokenProvider.createRefreshToken(kakaoUserInfo.getEmail());
+
+        // 회원 가입이 안되어있는 경우(최초 로그인 시)
+        if (user == null) {
+            user = UserResponse.toEntity(userService.signUp(kakaoUserInfo.getEmail(), kakaoUserInfo.getName()));
+
+            RefreshToken newRefreshToken = RefreshToken.toEntity(user.getEmail(),
+                    newToken_RefreshToken.getRefreshToken());
+
+            refreshTokenRepository.save(newRefreshToken);
+
+            return getBuild(newToken_AccessToken.getAccessToken(), newToken_RefreshToken.getRefreshToken(), user,
+                    tokenResponse.getRefreshToken());
+        }
+
+        RefreshToken refreshToken = refreshTokenRepository.findByKeyEmail(user.getEmail())
+                .orElseThrow(IllegalArgumentException::new);
+
+        System.out.println(refreshToken);
+        return getBuild(newToken_AccessToken.getAccessToken(), refreshToken.getRefreshToken(), user,
+                tokenResponse.getRefreshToken());
+    }
+
+    private JwtResponse getBuild(final String accessToken, final String refreshToken, final User user,
+                                 final String oauthRefreshToken) {
+        return JwtResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .userId(user.getId())
+                .oauthRefreshToken(oauthRefreshToken)
+                .build();
+    }
+
+    @Override
+    public TokenResponse getToken(final String code) {
+        return kakaoAuthClient.getToken(GRANT_TYPE, CLIENT_ID, REDIRECT_URI, code);
+    }
+
+    @Override
+    public KakaoUserInfo getUserInfo(final String accessToken) {
+        return kakaoInfoClient.getUserInfo("Bearer " + accessToken);
+    }
+
+    @Override
+    public KakaoUnlinkResponse unLink(final String accessToken) {
+        return kakaoInfoClient.unlink("Bearer " + accessToken);
+    }
+
+    public OauthRefresh refresh(final String refreshToken) {
+        return kakaoAuthClient.refresh("refresh_token", CLIENT_ID, refreshToken);
+    }
+
+}

--- a/src/main/java/com/mindgoal/domain/user/service/auth/PrincipalDetailService.java
+++ b/src/main/java/com/mindgoal/domain/user/service/auth/PrincipalDetailService.java
@@ -1,0 +1,20 @@
+package com.mindgoal.domain.user.service.auth;
+
+import com.mindgoal.domain.user.entity.auth.PrincipalDetails;
+import com.mindgoal.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PrincipalDetailService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public PrincipalDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        return new PrincipalDetails(userRepository.findUserByEmail(email));
+    }
+}

--- a/src/main/java/com/mindgoal/domain/user/service/auth/RequestService.java
+++ b/src/main/java/com/mindgoal/domain/user/service/auth/RequestService.java
@@ -1,0 +1,15 @@
+package com.mindgoal.domain.user.service.auth;
+
+import com.mindgoal.domain.user.dto.JwtResponse;
+import com.mindgoal.domain.user.dto.KakaoUnlinkResponse;
+import com.mindgoal.domain.user.dto.TokenResponse;
+
+public interface RequestService<T> {
+    JwtResponse redirect(String provider, String code, String state);
+
+    TokenResponse getToken(String code);
+
+    T getUserInfo(String accessToken);
+
+    KakaoUnlinkResponse unLink(String accessToken);
+}

--- a/src/main/java/com/mindgoal/domain/user/service/feign/KakaoAuthClient.java
+++ b/src/main/java/com/mindgoal/domain/user/service/feign/KakaoAuthClient.java
@@ -1,0 +1,26 @@
+package com.mindgoal.domain.user.service.feign;
+
+
+import com.mindgoal.domain.user.dto.OauthRefresh;
+import com.mindgoal.domain.user.dto.TokenResponse;
+import feign.Headers;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "kakao-auth", url = "https://kauth.kakao.com")
+public interface KakaoAuthClient {
+
+    @PostMapping("/oauth/token")
+    TokenResponse getToken(@RequestParam("grant_type") String grantType,
+                           @RequestParam("client_id") String clientId,
+                           @RequestParam("redirect_uri") String redirectUri,
+                           @RequestParam("code") String code
+    );
+
+    @PostMapping("/oauth/token")
+    @Headers("Content-type: application/x-www-form-urlencoded;charset=utf-8")
+    OauthRefresh refresh(@RequestParam("grant_type") String grantType,
+                         @RequestParam("client_id") String clientId,
+                         @RequestParam("refresh_token") String refreshToken);
+}

--- a/src/main/java/com/mindgoal/domain/user/service/feign/KakaoInfoClient.java
+++ b/src/main/java/com/mindgoal/domain/user/service/feign/KakaoInfoClient.java
@@ -1,0 +1,19 @@
+package com.mindgoal.domain.user.service.feign;
+
+
+import com.mindgoal.domain.user.dto.KakaoUnlinkResponse;
+import com.mindgoal.domain.user.dto.KakaoUserInfo;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(name = "kakao-info", url = "https://kapi.kakao.com")
+public interface KakaoInfoClient {
+
+    @GetMapping("/v2/user/me")
+    KakaoUserInfo getUserInfo(@RequestHeader("Authorization") String authorization);
+
+    @PostMapping(value = "/v1/user/unlink")
+    KakaoUnlinkResponse unlink(@RequestHeader("Authorization") String authorization);
+}

--- a/src/test/java/com/mindgoal/backend/chat/service/ChatServiceTest.java
+++ b/src/test/java/com/mindgoal/backend/chat/service/ChatServiceTest.java
@@ -25,26 +25,6 @@ public class ChatServiceTest {
     private ChatService chatService;
 
     @Test
-    void 채팅방_생성() {
-        Expert expert = ExpertFixture.심리_전문가();
-        User user = UserFixture.오션();
-        ChatRoomRequest chatRoomRequest = new ChatRoomRequest(expert.getId(), "defaultImage");
-        chatService.saveChatRoom(chatRoomRequest, user.getId());
-        assertThat(chatRoomRepository.count()).isNotNull();
-    }
-
-    @Test
-    void 채팅방이_이미_존재할_경우_에외처리() {
-        Expert expert = ExpertFixture.심리_전문가();
-        User user = UserFixture.오션();
-        ChatRoomRequest chatRoomRequest = new ChatRoomRequest(expert.getId(), "defaultImage");
-        ChatRoom chatRoom = ChatRoomFixture.오션_심리_채팅방();
-        chatRoomRepository.save(chatRoom);
-        assertThatThrownBy(() -> chatService.saveChatRoom(chatRoomRequest, user.getId())).isExactlyInstanceOf(
-                IllegalArgumentException.class);
-    }
-
-    @Test
     void 채팅방_조회() {
         User user = UserFixture.오션();
         ChatRoom chatRoom1 = ChatRoomFixture.오션_심리_채팅방();

--- a/src/test/java/com/mindgoal/backend/support/fixture/user/UserFixture.java
+++ b/src/test/java/com/mindgoal/backend/support/fixture/user/UserFixture.java
@@ -4,18 +4,18 @@ import com.mindgoal.domain.user.entity.User;
 
 public class UserFixture {
     public static User 오션() {
-        return new User(1L, "email@gmail.com", "password", "오션", "010-0000-1111", "https://images", false);
+        return new User(1L, "email@gmail.com", "오션", "010-0000-1111", "https://images", false);
     }
 
     public static User 스텝() {
-        return new User(2L, "email@naver.com", "password22", "ocean", "010-0000-2222", "https://images", true);
+        return new User(2L, "email@naver.com", "ocean", "010-0000-2222", "https://images", true);
     }
 
     public static User 심리_전문가() {
-        return new User(3L, "email@naver.com", "password22", "ocean", "010-0000-2222", "https://images", true);
+        return new User(3L, "email@naver.com", "ocean", "010-0000-2222", "https://images", true);
     }
 
     public static User 진로_전문가() {
-        return new User(4L, "email@naver.com", "password22", "ocean", "010-0000-2222", "https://images", true);
+        return new User(4L, "email@naver.com", "ocean", "010-0000-2222", "https://images", true);
     }
 }

--- a/src/test/java/com/mindgoal/backend/user/service/UserServiceTest.java
+++ b/src/test/java/com/mindgoal/backend/user/service/UserServiceTest.java
@@ -113,7 +113,6 @@ class UserServiceTest {
     private User createUser(String email, String name, String profileImage) {
         User user = User.builder()
                 .email(email)
-                .password("password1234")
                 .name(name)
                 .profileImage(profileImage)
                 .build();


### PR DESCRIPTION
# Pull Request

## 💡 PR 요약

> 이 PR에서 작업한 내용을 간단히 설명해주세요

## 🔍 주요 변경사항

> 구체적인 변경 내용을 설명해주세요
> - 카카오로그인기능 수정
> - 채팅메시지 생성기능 구현(미 테스트)
> - 아래 스크린샷처럼 직접 redirect-url 및 secret키 없이 기본 로그인신청 주소로 로그인 url이 되게 매핑수정 
> - 로그인 후 자연스레 토큰정보가 페이지에 redirect되도록 변경

## 🔗 연관된 이슈

> 관련 이슈를 링크해주세요 (예: #이슈번호)

## 📸 스크린샷 (선택)
<img width="427" alt="image" src="https://github.com/user-attachments/assets/205717cd-e058-4c38-a708-342cf299c47b" />

<img width="1043" alt="image" src="https://github.com/user-attachments/assets/04fe0c5f-65bb-43f9-beed-42ca770346d1" />

> UI 변경사항이 있다면 스크린샷을 첨부해주세요

## ✅ 체크리스트

- [ ] 테스트 코드를 작성하였나요?
- [ ] 관련 문서를 업데이트하였나요?
- [ ] Breaking Change가 있나요?
- [ ] 코드 포맷팅과 린트 검사를 완료하였나요?

## 🙏 리뷰어 참고사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> 예시:
> - 특정 로직에 대한 의견이 필요합니다
> - 성능 개선 방안에 대한 피드백 부탁드립니다
> - 더 나은 네이밍 제안이 있다면 알려주세요

## 📋 추가 컨텍스트 (선택)

> PR에 대한 추가적인 설명이나 컨텍스트가 있다면 작성해주세요
