### PR TITLE
[Refactor/user] 사용자 인증 로직 개선 및 테스트 코드 수정

### DIFF
--- a/src/main/java/com/mindgoal/domain/expert/controller/ExpertController.java
+++ b/src/main/java/com/mindgoal/domain/expert/controller/ExpertController.java
@@ -4,6 +4,7 @@ import com.mindgoal.common.BaseResponse;
 import com.mindgoal.common.BaseResponseStatus;
 import com.mindgoal.domain.expert.dto.*;
 import com.mindgoal.domain.expert.service.ExpertService;
+import com.mindgoal.domain.user.entity.auth.PrincipalDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -12,6 +13,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -22,8 +24,9 @@ public class ExpertController {
 
     @PostMapping
     public ResponseEntity<BaseResponse<ExpertResponse>> register(
-            @RequestBody @Valid ExpertCreateRequest request) {
-        ExpertResponse response = expertService.register(request);
+            @RequestBody @Valid ExpertCreateRequest request,
+            @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        ExpertResponse response = expertService.register(request, principalDetails.getId());
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(BaseResponse.success(response, BaseResponseStatus.EXPERT_REGISTER_SUCCESS.getMessage()));
@@ -65,11 +68,12 @@ public class ExpertController {
         );
     }
 
-    @PutMapping("/{Id}")
+    @PutMapping("/{expertId}")
     public ResponseEntity<BaseResponse<ExpertUpdateResponse>> updateExpert(
             @PathVariable Long expertId,
-            @RequestBody @Valid ExpertUpdateRequest request) {
-        ExpertUpdateResponse response = expertService.updateExpert(expertId, request);
+            @RequestBody @Valid ExpertUpdateRequest request,
+            @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        ExpertUpdateResponse response = expertService.updateExpert(expertId, request, principalDetails.getId());
         return ResponseEntity.ok(
                 BaseResponse.success(response, BaseResponseStatus.EXPERT_UPDATE_SUCCESS.getMessage())
         );

--- a/src/main/java/com/mindgoal/domain/expert/service/ExpertService.java
+++ b/src/main/java/com/mindgoal/domain/expert/service/ExpertService.java
@@ -20,14 +20,13 @@ public class ExpertService {
     private final UserService userService;
 
     @Transactional
-    public ExpertResponse register(ExpertCreateRequest request) {
-        User currentUser = userService.getCurrentUser();
-
-        if (expertRepository.existsByUserId(currentUser.getId())) {
+    public ExpertResponse register(ExpertCreateRequest request, Long userId) {
+        if (expertRepository.existsByUserId(userId)) {
             throw new CustomException(BaseResponseStatus.EXPERT_ALREADY_EXISTS);
         }
 
-        Expert expert = createExpertEntity(currentUser, request);
+        User user = userService.getUser(userId);
+        Expert expert = createExpertEntity(user, request);
         Expert savedExpert = expertRepository.save(expert);
         return ExpertResponse.from(savedExpert);
     }
@@ -68,11 +67,10 @@ public class ExpertService {
     }
 
     @Transactional
-    public ExpertUpdateResponse updateExpert(Long expertId, ExpertUpdateRequest request) {
+    public ExpertUpdateResponse updateExpert(Long expertId, ExpertUpdateRequest request, Long currentUserId) {
         Expert expert = expertRepository.findExpertById(expertId);
-        User currentUser = userService.getCurrentUser();
 
-        if (!expert.getUserId().equals(currentUser.getId())) {
+        if (!expert.getUserId().equals(currentUserId)) {
             throw new CustomException(BaseResponseStatus.UNAUTHORIZED_ACCESS);
         }
 
@@ -112,6 +110,4 @@ public class ExpertService {
                 .mentalScore(0)
                 .build();
     }
-
-
 }

--- a/src/main/java/com/mindgoal/domain/user/controller/UserController.java
+++ b/src/main/java/com/mindgoal/domain/user/controller/UserController.java
@@ -6,6 +6,7 @@ import com.mindgoal.domain.user.dto.KakaoLoginRequest;
 import com.mindgoal.domain.user.dto.TokenDto;
 import com.mindgoal.domain.user.dto.UpdateUserRequest;
 import com.mindgoal.domain.user.entity.User;
+import com.mindgoal.domain.user.entity.auth.PrincipalDetails;
 import com.mindgoal.domain.user.service.UserService;
 import com.mindgoal.domain.user.service.auth.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -17,6 +18,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -32,20 +34,24 @@ public class UserController {
     }
 
     @GetMapping("/user/me")
-    public ResponseEntity<BaseResponse<User>> getCurrentUser() {
-        User user = userService.getCurrentUser();
+    public ResponseEntity<BaseResponse<User>> getCurrentUser(
+            @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        User user = userService.getUser(principalDetails.getId());
         return ResponseEntity.ok(BaseResponse.success(user, "사용자 정보 조회 성공"));
     }
 
     @PutMapping("/user/me")
-    public ResponseEntity<BaseResponse<User>> updateMyInfo(@RequestBody @Valid UpdateUserRequest request) {
-        User updatedUser = userService.updateUser(request);
+    public ResponseEntity<BaseResponse<User>> updateMyInfo(
+            @RequestBody @Valid UpdateUserRequest request,
+            @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        User updatedUser = userService.updateUser(request, principalDetails.getId());
         return ResponseEntity.ok(BaseResponse.success(updatedUser, "내 정보 수정 성공"));
     }
 
     @DeleteMapping("/user/me")
-    public ResponseEntity<BaseResponse<Void>> withdrawUser() {
-        userService.withdrawUser();
+    public ResponseEntity<BaseResponse<Void>> withdrawUser(
+            @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        userService.withdrawUser(principalDetails.getId());
         return ResponseEntity.ok(BaseResponse.success(null, "회원 탈퇴 성공"));
     }
 }

--- a/src/main/java/com/mindgoal/domain/user/service/UserService.java
+++ b/src/main/java/com/mindgoal/domain/user/service/UserService.java
@@ -23,7 +23,6 @@ public class UserService {
 
     @Transactional
     public UserResponse signUp(final String email, final String name) {
-
         User user = User.builder()
                 .email(email)
                 .name(name)
@@ -42,37 +41,28 @@ public class UserService {
         if (session != null) {
             session.invalidate();
         }
-
-        // 현재 스레드의 로컬 컨텍스트 정리
-        SecurityContextHolder.getContext().setAuthentication(null);
-    }
-
-    public User getCurrentUser() {
-        String email = SecurityContextHolder.getContext().getAuthentication().getName();
-        return userRepository.findByEmailAndIsDeletedFalse(email)
-                .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + email));
     }
 
     @Transactional
-    public User updateUser(UpdateUserRequest request) {
-        User user = getCurrentUser();
+    public User updateUser(UpdateUserRequest request, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
         user.updateProfile(request.getName(), request.getProfileImage());
         return userRepository.save(user);
     }
 
     @Transactional
-    public void withdrawUser() {
-        User user = getCurrentUser();
-        user.withdraw(); // 실제 삭제 대신 상태만 변경
-        userRepository.save(user); // 변경된 상태를 저장
-        SecurityContextHolder.clearContext();
+    public void withdrawUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        user.withdraw();
+        userRepository.save(user);
     }
 
     @Transactional(readOnly = true)
     public User getUser(Long userId) {
         return userRepository.findById(userId)
-                .filter(user -> !user.isDeleted())  // isDeleted가 false인 사용자만 필터링
+                .filter(user -> !user.isDeleted())
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
     }
-
 }

--- a/src/test/java/com/mindgoal/backend/expert/service/ExpertServiceTest.java
+++ b/src/test/java/com/mindgoal/backend/expert/service/ExpertServiceTest.java
@@ -33,15 +33,8 @@ class ExpertServiceTest {
     @Autowired
     private UserRepository userRepository;
 
-    @Mock
-    private SecurityContext securityContext;
-
-    @Mock
-    private Authentication authentication;
-
     @BeforeEach
     void setUp() {
-        SecurityContextHolder.clearContext();
         expertRepository.deleteAll();
         userRepository.deleteAll();
     }
@@ -51,11 +44,10 @@ class ExpertServiceTest {
     void register_Success() {
         // given
         User user = createUser("test@example.com", "testUser");
-        setSecurityContext(user.getEmail());
         ExpertCreateRequest request = createExpertRequest();
 
         // when
-        ExpertResponse response = expertService.register(request);
+        ExpertResponse response = expertService.register(request, user.getId());
 
         // then
         assertThat(response)
@@ -90,13 +82,12 @@ class ExpertServiceTest {
     void register_AlreadyExistExpert_ThrowsException() {
         // given
         User user = createUser("test@example.com", "testUser");
-        setSecurityContext(user.getEmail());
         Expert expert = createExpert(user.getId());
         ExpertCreateRequest request = createExpertRequest();
 
         // when & then
         assertThrows(CustomException.class,
-                () -> expertService.register(request));
+                () -> expertService.register(request, user.getId()));
     }
 
     @DisplayName("전문가 등록시 초기값 설정 확인")
@@ -104,11 +95,10 @@ class ExpertServiceTest {
     void register_CheckInitialValues() {
         // given
         User user = createUser("test@example.com", "testUser");
-        setSecurityContext(user.getEmail());
         ExpertCreateRequest request = createExpertRequest();
 
         // when
-        ExpertResponse response = expertService.register(request);
+        ExpertResponse response = expertService.register(request, user.getId());
 
         // then
         assertThat(response)
@@ -195,10 +185,116 @@ class ExpertServiceTest {
                 });
     }
 
-    private void setSecurityContext(String email) {
-        when(securityContext.getAuthentication()).thenReturn(authentication);
-        when(authentication.getName()).thenReturn(email);
-        SecurityContextHolder.setContext(securityContext);
+    @DisplayName("전문가 정보 수정 성공")
+    @Test
+    void updateExpert_Success() {
+        // given
+        User user = createUser("test@example.com", "testUser");
+        Expert expert = createExpert(user.getId());
+
+        ExpertUpdateRequest request = ExpertUpdateRequest.builder()
+                .specialty("수정된 전문 분야")
+                .position("수정된 포지션")
+                .description("수정된 설명")
+                .careerHistory("수정된 경력")
+                .teachingMethod("수정된 교육방식")
+                .pricePerHour(60000)
+                .youtubeUrl("https://youtube.com/updated")
+                .instagramUrl("https://instagram.com/updated")
+                .build();
+
+        // when
+        ExpertUpdateResponse response = expertService.updateExpert(expert.getId(), request, user.getId());
+
+        // then
+        Expert updatedExpert = expertRepository.findById(expert.getId())
+                .orElseThrow(() -> new AssertionError("Expert should exist"));
+
+        assertThat(updatedExpert)
+                .satisfies(e -> {
+                    assertThat(e.getSpeciality()).isEqualTo("수정된 전문 분야");
+                    assertThat(e.getPosition()).isEqualTo("수정된 포지션");
+                    assertThat(e.getDescription()).isEqualTo("수정된 설명");
+                    assertThat(e.getCareerHistory()).isEqualTo("수정된 경력");
+                    assertThat(e.getTeachingMethod()).isEqualTo("수정된 교육방식");
+                    assertThat(e.getPricePerHour()).isEqualTo(60000);
+                    assertThat(e.getYoutubeUrl()).isEqualTo("https://youtube.com/updated");
+                    assertThat(e.getInstagramUrl()).isEqualTo("https://instagram.com/updated");
+                });
+
+        assertThat(response)
+                .satisfies(r -> {
+                    assertThat(r.getId()).isEqualTo(expert.getId());
+                    assertThat(r.getUpdatedAt()).isNotNull();
+                });
+    }
+
+    @DisplayName("전문가 정보 부분 수정 성공")
+    @Test
+    void updateExpert_PartialUpdate_Success() {
+        // given
+        User user = createUser("test@example.com", "testUser");
+        Expert expert = createExpert(user.getId());
+
+        ExpertUpdateRequest request = ExpertUpdateRequest.builder()
+                .specialty("수정된 전문 분야")
+                .pricePerHour(60000)
+                .build();
+
+        // when
+        ExpertUpdateResponse response = expertService.updateExpert(expert.getId(), request, user.getId());
+
+        // then
+        Expert updatedExpert = expertRepository.findById(expert.getId())
+                .orElseThrow(() -> new AssertionError("Expert should exist"));
+
+        assertThat(updatedExpert)
+                .satisfies(e -> {
+                    // 수정된 필드
+                    assertThat(e.getSpeciality()).isEqualTo("수정된 전문 분야");
+                    assertThat(e.getPricePerHour()).isEqualTo(60000);
+
+                    // 기존 값이 유지되어야 하는 필드들
+                    assertThat(e.getPosition()).isEqualTo("공격수");
+                    assertThat(e.getDescription()).isEqualTo("전문가 설명");
+                    assertThat(e.getCareerHistory()).isEqualTo("경력 사항");
+                    assertThat(e.getTeachingMethod()).isEqualTo("교육 방식");
+                });
+
+        assertThat(response.getId()).isEqualTo(expert.getId());
+    }
+
+    @DisplayName("존재하지 않는 전문가 정보 수정 실패")
+    @Test
+    void updateExpert_NotFound_ThrowsException() {
+        // given
+        User user = createUser("test@example.com", "testUser");
+        Long nonExistentExpertId = 999L;
+
+        ExpertUpdateRequest request = ExpertUpdateRequest.builder()
+                .specialty("수정된 전문 분야")
+                .build();
+
+        // when & then
+        assertThrows(CustomException.class,
+                () -> expertService.updateExpert(nonExistentExpertId, request, user.getId()));
+    }
+
+    @DisplayName("권한 없는 사용자의 전문가 정보 수정 실패")
+    @Test
+    void updateExpert_UnauthorizedAccess_ThrowsException() {
+        // given
+        User owner = createUser("owner@example.com", "owner");
+        User other = createUser("other@example.com", "other");
+        Expert expert = createExpert(owner.getId());
+
+        ExpertUpdateRequest request = ExpertUpdateRequest.builder()
+                .specialty("수정된 전문 분야")
+                .build();
+
+        // when & then
+        assertThrows(CustomException.class,
+                () -> expertService.updateExpert(expert.getId(), request, other.getId()));
     }
 
     private User createUser(String email, String name) {
@@ -244,121 +340,5 @@ class ExpertServiceTest {
                 .teachingMethod("1:1 맞춤형 기술 훈련")
                 .pricePerHour(50000)
                 .build();
-    }
-    @DisplayName("전문가 정보 수정 성공")
-    @Test
-    void updateExpert_Success() {
-        // given
-        User user = createUser("test@example.com", "testUser");
-        setSecurityContext(user.getEmail());
-        Expert expert = createExpert(user.getId());
-
-        ExpertUpdateRequest request = ExpertUpdateRequest.builder()
-                .specialty("수정된 전문 분야")
-                .position("수정된 포지션")
-                .description("수정된 설명")
-                .careerHistory("수정된 경력")
-                .teachingMethod("수정된 교육방식")
-                .pricePerHour(60000)
-                .youtubeUrl("https://youtube.com/updated")
-                .instagramUrl("https://instagram.com/updated")
-                .build();
-
-        // when
-        ExpertUpdateResponse response = expertService.updateExpert(expert.getId(), request);
-
-        // then
-        Expert updatedExpert = expertRepository.findById(expert.getId())
-                .orElseThrow(() -> new AssertionError("Expert should exist"));
-
-        assertThat(updatedExpert)
-                .satisfies(e -> {
-                    assertThat(e.getSpeciality()).isEqualTo("수정된 전문 분야");
-                    assertThat(e.getPosition()).isEqualTo("수정된 포지션");
-                    assertThat(e.getDescription()).isEqualTo("수정된 설명");
-                    assertThat(e.getCareerHistory()).isEqualTo("수정된 경력");
-                    assertThat(e.getTeachingMethod()).isEqualTo("수정된 교육방식");
-                    assertThat(e.getPricePerHour()).isEqualTo(60000);
-                    assertThat(e.getYoutubeUrl()).isEqualTo("https://youtube.com/updated");
-                    assertThat(e.getInstagramUrl()).isEqualTo("https://instagram.com/updated");
-                });
-
-        assertThat(response)
-                .satisfies(r -> {
-                    assertThat(r.getId()).isEqualTo(expert.getId());
-                    assertThat(r.getUpdatedAt()).isNotNull();
-                });
-    }
-
-    @DisplayName("전문가 정보 부분 수정 성공")
-    @Test
-    void updateExpert_PartialUpdate_Success() {
-        // given
-        User user = createUser("test@example.com", "testUser");
-        setSecurityContext(user.getEmail());
-        Expert expert = createExpert(user.getId());
-
-        ExpertUpdateRequest request = ExpertUpdateRequest.builder()
-                .specialty("수정된 전문 분야")
-                .pricePerHour(60000)
-                .build();
-
-        // when
-        ExpertUpdateResponse response = expertService.updateExpert(expert.getId(), request);
-
-        // then
-        Expert updatedExpert = expertRepository.findById(expert.getId())
-                .orElseThrow(() -> new AssertionError("Expert should exist"));
-
-        assertThat(updatedExpert)
-                .satisfies(e -> {
-                    // 수정된 필드
-                    assertThat(e.getSpeciality()).isEqualTo("수정된 전문 분야");
-                    assertThat(e.getPricePerHour()).isEqualTo(60000);
-
-                    // 기존 값이 유지되어야 하는 필드들
-                    assertThat(e.getPosition()).isEqualTo("공격수");
-                    assertThat(e.getDescription()).isEqualTo("전문가 설명");
-                    assertThat(e.getCareerHistory()).isEqualTo("경력 사항");
-                    assertThat(e.getTeachingMethod()).isEqualTo("교육 방식");
-                });
-
-        assertThat(response.getId()).isEqualTo(expert.getId());
-    }
-
-    @DisplayName("존재하지 않는 전문가 정보 수정 실패")
-    @Test
-    void updateExpert_NotFound_ThrowsException() {
-        // given
-        User user = createUser("test@example.com", "testUser");
-        setSecurityContext(user.getEmail());
-        Long nonExistentExpertId = 999L;
-
-        ExpertUpdateRequest request = ExpertUpdateRequest.builder()
-                .specialty("수정된 전문 분야")
-                .build();
-
-        // when & then
-        assertThrows(CustomException.class,
-                () -> expertService.updateExpert(nonExistentExpertId, request));
-    }
-
-    @DisplayName("권한 없는 사용자의 전문가 정보 수정 실패")
-    @Test
-    void updateExpert_UnauthorizedAccess_ThrowsException() {
-        // given
-        User owner = createUser("owner@example.com", "owner");
-        User other = createUser("other@example.com", "other");
-        Expert expert = createExpert(owner.getId());
-
-        setSecurityContext(other.getEmail());
-
-        ExpertUpdateRequest request = ExpertUpdateRequest.builder()
-                .specialty("수정된 전문 분야")
-                .build();
-
-        // when & then
-        assertThrows(CustomException.class,
-                () -> expertService.updateExpert(expert.getId(), request));
     }
 }

--- a/src/test/java/com/mindgoal/backend/user/service/UserServiceTest.java
+++ b/src/test/java/com/mindgoal/backend/user/service/UserServiceTest.java
@@ -28,15 +28,9 @@ class UserServiceTest {
     @Autowired
     private UserRepository userRepository;
 
-    @MockBean
-    private SecurityContext securityContext;
-
-    @MockBean
-    private Authentication authentication;
-
     @BeforeEach
     void setUp() {
-        SecurityContextHolder.clearContext();
+        userRepository.deleteAll();
     }
 
     @DisplayName("사용자 정보 업데이트 성공")
@@ -44,7 +38,6 @@ class UserServiceTest {
     void updateUser_Success() {
         // given
         User savedUser = createUser("test@example.com", "oldName", "old.jpg");
-        setSecurityContext(savedUser.getEmail());
 
         UpdateUserRequest request = UpdateUserRequest.builder()
                 .name("newName")
@@ -52,7 +45,7 @@ class UserServiceTest {
                 .build();
 
         // when
-        User updatedUser = userService.updateUser(request);
+        User updatedUser = userService.updateUser(request, savedUser.getId());
 
         // then
         assertThat(updatedUser)
@@ -60,7 +53,7 @@ class UserServiceTest {
                 .containsExactly("newName", "newImage.jpg");
 
         // DB 검증
-        User foundUser = userRepository.findByEmailAndIsDeletedFalse(savedUser.getEmail())
+        User foundUser = userRepository.findById(savedUser.getId())
                 .orElseThrow(() -> new AssertionError("User should exist"));
         assertThat(foundUser)
                 .extracting("name", "profileImage")
@@ -71,17 +64,15 @@ class UserServiceTest {
     @Test
     void updateUser_UserNotFound_ThrowsException() {
         // given
-        String nonExistentEmail = "nonexistent@example.com";
-        setSecurityContext(nonExistentEmail);
-
+        Long nonExistentUserId = 999L;
         UpdateUserRequest request = UpdateUserRequest.builder()
                 .name("newName")
                 .profileImage("newImage.jpg")
                 .build();
 
         // when & then
-        assertThrows(UsernameNotFoundException.class,
-                () -> userService.updateUser(request));
+        assertThrows(IllegalArgumentException.class,
+                () -> userService.updateUser(request, nonExistentUserId));
     }
 
     @DisplayName("사용자 정보 부분 업데이트 - 이름만 변경")
@@ -89,25 +80,18 @@ class UserServiceTest {
     void updateUser_NameOnly() {
         // given
         User savedUser = createUser("test@example.com", "oldName", "old.jpg");
-        setSecurityContext(savedUser.getEmail());
 
         UpdateUserRequest request = UpdateUserRequest.builder()
                 .name("newName")
                 .build();
 
         // when
-        User updatedUser = userService.updateUser(request);
+        User updatedUser = userService.updateUser(request, savedUser.getId());
 
         // then
         assertThat(updatedUser)
                 .extracting("name", "profileImage")
                 .containsExactly("newName", "old.jpg");
-    }
-
-    private void setSecurityContext(String email) {
-        when(securityContext.getAuthentication()).thenReturn(authentication);
-        when(authentication.getName()).thenReturn(email);
-        SecurityContextHolder.setContext(securityContext);
     }
 
     private User createUser(String email, String name, String profileImage) {


### PR DESCRIPTION
# Pull Request

## 💡 PR 요약
사용자 인증 로직 개선 및 테스트 코드 수정

## 🔍 주요 변경사항
- SecurityContext 직접 사용 제거하고 PrincipalDetails를 통한 인증 방식으로 변경
- getCurrentUser() 메서드 제거하고 userId를 직접 전달하는 방식으로 개선
- UserService, ExpertService의 인증/인가 로직 보안 강화
- 관련 테스트 코드 수정 및 테스트 환경 설정 보완

세부 변경사항:
1. UserService 수정
  - getCurrentUser() 메서드 제거
  - userId를 파라미터로 받아 처리하도록 변경
  - 인증 관련 로직을 컨트롤러 계층으로 이동

2. ExpertService 수정
  - SecurityContext 직접 사용 제거
  - userId 기반 인증 처리로 변경
  - 전문가 등록/수정 시 권한 검증 로직 개선

3. 테스트 코드 수정
  - UserServiceTest의 인증 관련 테스트 수정
  - ExpertServiceTest 시큐리티 설정 개선


## 🔗 연관된 이슈
close #이슈번호

## ✅ 체크리스트
- [x] 테스트 코드를 작성하였나요?
- [x] 관련 문서를 업데이트하였나요?
- [x] Breaking Change가 있나요?
- [x] 코드 포맷팅과 린트 검사를 완료하였나요?

## 🙏 리뷰어 참고사항


## 📋 추가 컨텍스트
