### PR TITLE
카카오 로그인 시 카카오측에서 넘겨주는 유저정보 json 파싱오류 해결

### DIFF
--- a/src/main/java/com/mindgoal/domain/user/dto/KakaoUserInfo.java
+++ b/src/main/java/com/mindgoal/domain/user/dto/KakaoUserInfo.java
@@ -1,5 +1,6 @@
 package com.mindgoal.domain.user.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -8,6 +9,8 @@ import lombok.NoArgsConstructor;
 public class KakaoUserInfo {
 
     private Long id;
+
+    @JsonProperty("kakao_account")
     private KakaoAccount kakaoAccount;
 
     public String getEmail() {
@@ -15,18 +18,24 @@ public class KakaoUserInfo {
     }
 
     public String getName() {
-        return kakaoAccount != null ? kakaoAccount.getProfile().getNickname() : null;
+        return kakaoAccount != null && kakaoAccount.getProfile() != null
+                ? kakaoAccount.getProfile().getNickname() : null;
     }
 
     @Getter
-    private static class KakaoAccount {
+    public static class KakaoAccount {
         private String email;
+
+        @JsonProperty("profile")
         private Profile profile;
 
         @Getter
-        private static class Profile {
+        public static class Profile {
+            @JsonProperty("nickname")
             private String nickname;
-            private String profileImageUrl;
+
+            @JsonProperty("profile_image")
+            private String profile_image;
         }
     }
 }

--- a/src/main/java/com/mindgoal/domain/user/service/UserService.java
+++ b/src/main/java/com/mindgoal/domain/user/service/UserService.java
@@ -10,7 +10,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/com/mindgoal/domain/user/service/auth/KakaoRequestService.java
+++ b/src/main/java/com/mindgoal/domain/user/service/auth/KakaoRequestService.java
@@ -47,7 +47,6 @@ public class KakaoRequestService implements RequestService {
     public JwtResponse redirect(final String provider, final String code, final String state) {
         // 카카오에서 넘겨준 엑세스 토큰
         TokenResponse tokenResponse = getToken(code);
-        System.out.println(tokenResponse);
         // 카카오에서 넘겨준 유저 정보
         KakaoUserInfo kakaoUserInfo = getUserInfo(tokenResponse.getAccessToken());
 
@@ -73,7 +72,6 @@ public class KakaoRequestService implements RequestService {
         RefreshToken refreshToken = refreshTokenRepository.findByKeyEmail(user.getEmail())
                 .orElseThrow(IllegalArgumentException::new);
 
-        System.out.println(refreshToken);
         return getBuild(newToken_AccessToken.getAccessToken(), refreshToken.getRefreshToken(), user,
                 tokenResponse.getRefreshToken());
     }
@@ -106,5 +104,4 @@ public class KakaoRequestService implements RequestService {
     public OauthRefresh refresh(final String refreshToken) {
         return kakaoAuthClient.refresh("refresh_token", CLIENT_ID, refreshToken);
     }
-
 }

--- a/src/test/java/com/mindgoal/MindGoalBackendApplicationTest.java
+++ b/src/test/java/com/mindgoal/MindGoalBackendApplicationTest.java
@@ -2,8 +2,10 @@ package com.mindgoal;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class MindGoalBackendApplicationTest {
     @Test
     void contextLoads() {

--- a/src/test/java/com/mindgoal/backend/user/service/UserServiceTest.java
+++ b/src/test/java/com/mindgoal/backend/user/service/UserServiceTest.java
@@ -16,6 +16,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
@@ -27,11 +28,6 @@ class UserServiceTest {
 
     @Autowired
     private UserRepository userRepository;
-
-    @BeforeEach
-    void setUp() {
-        userRepository.deleteAll();
-    }
 
     @DisplayName("사용자 정보 업데이트 성공")
     @Test
@@ -71,8 +67,8 @@ class UserServiceTest {
                 .build();
 
         // when & then
-        assertThrows(IllegalArgumentException.class,
-                () -> userService.updateUser(request, nonExistentUserId));
+        assertThatThrownBy(() -> userService.updateUser(request, nonExistentUserId))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @DisplayName("사용자 정보 부분 업데이트 - 이름만 변경")


### PR DESCRIPTION
# Pull Request

## 💡 PR 요약

> 이 PR에서 작업한 내용을 간단히 설명해주세요

## 🔍 주요 변경사항

> 구체적인 변경 내용을 설명해주세요
> - 카카오 로그인 시 카카오측에서 넘겨주는 유저정보 json 파싱오류 해결

## 🔗 연관된 이슈

> 관련 이슈를 링크해주세요 (예: #이슈번호)

## 📸 스크린샷 (선택)

> UI 변경사항이 있다면 스크린샷을 첨부해주세요

## ✅ 체크리스트

- [ ] 테스트 코드를 작성하였나요?
- [ ] 관련 문서를 업데이트하였나요?
- [ ] Breaking Change가 있나요?
- [ ] 코드 포맷팅과 린트 검사를 완료하였나요?

## 🙏 리뷰어 참고사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> 예시:
> - 특정 로직에 대한 의견이 필요합니다
> - 성능 개선 방안에 대한 피드백 부탁드립니다
> - 더 나은 네이밍 제안이 있다면 알려주세요

## 📋 추가 컨텍스트 (선택)

> PR에 대한 추가적인 설명이나 컨텍스트가 있다면 작성해주세요
