### PR TITLE
[Mind-22] 매칭 요청 취소 기능 구현

### DIFF
--- a/src/main/java/com/mindgoal/common/BaseResponseStatus.java
+++ b/src/main/java/com/mindgoal/common/BaseResponseStatus.java
@@ -10,6 +10,7 @@ public enum BaseResponseStatus {
     EXPERT_DETAIL_SUCCESS(true, 200, "전문가 상세 조회에 성공하였습니다"),
     EXPERT_UPDATE_SUCCESS(true, 200, "전문가 정보 수정이 성공했습니다"),
     MATCHING_REQUEST_SUCCESS(true, 201, "매칭 요청이 성공했습니다"),
+    MATCHING_CANCEL_SUCCESS(true, 200, "매칭 취소가 성공했습니다"),
 
     // 400번대: Request 오류
     BAD_REQUEST(false, 400, "잘못된 요청입니다"),
@@ -19,6 +20,8 @@ public enum BaseResponseStatus {
     METHOD_NOT_ALLOWED(false, 405, "허용되지 않은 메서드입니다"),
     EXPERT_ALREADY_EXISTS(false, 409, "이미 등록된 전문가입니다"),
     EXPERT_NOT_FOUND(false, 404, "전문가를 찾을 수 없습니다"),
+    MATCHING_NOT_FOUND(false, 404, "매칭 정보를 찾을 수 없습니다"),
+    MATCHING_ALREADY_CANCELED(false, 400, "이미 취소된 매칭입니다"),
     EXPIRED_ACCESS_TOKEN(false, 404, "만료된 토큰입니다."),
     UNSUPPORTED(false, 404, "지원하지 않는 토큰입니다."),
     TOKEN_NOT_FOUND(false, 404, "존재하지 않는 토큰입니다."),

--- a/src/main/java/com/mindgoal/domain/matching/controller/MatchingController.java
+++ b/src/main/java/com/mindgoal/domain/matching/controller/MatchingController.java
@@ -39,16 +39,17 @@ public class MatchingController {
 
     /**
      *
-     * @param id 매칭 ID
+     *
+     * @param matchingId 매칭 ID
      * @param principalDetails 인증된 사용자 정보
      * @return 취소된 매칭 정보
      */
-    @GetMapping("/{id}")
+    @GetMapping("/{matchingId}")
     public ResponseEntity<BaseResponse<MatchingResponseDto>> cancelMatching(
-            @PathVariable Long id,
+            @PathVariable Long matchingId,
             @AuthenticationPrincipal PrincipalDetails principalDetails) {
 
-        MatchingResponseDto response = matchingService.cancelMatching(id, principalDetails.getId());
+        MatchingResponseDto response = matchingService.cancelMatching(matchingId, principalDetails.getId());
         return ResponseEntity.ok(
                 BaseResponse.success(response, BaseResponseStatus.MATCHING_CANCEL_SUCCESS.getMessage()));
     }

--- a/src/main/java/com/mindgoal/domain/matching/controller/MatchingController.java
+++ b/src/main/java/com/mindgoal/domain/matching/controller/MatchingController.java
@@ -12,9 +12,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-/**
- * 매칭 API를 처리하는 컨트롤러 클래스
- */
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/matching")
@@ -38,5 +35,21 @@ public class MatchingController {
         return ResponseEntity
                 .status(BaseResponseStatus.MATCHING_REQUEST_SUCCESS.getCode())
                 .body(BaseResponse.success(response, BaseResponseStatus.MATCHING_REQUEST_SUCCESS.getMessage()));
+    }
+
+    /**
+     *
+     * @param id 매칭 ID
+     * @param principalDetails 인증된 사용자 정보
+     * @return 취소된 매칭 정보
+     */
+    @GetMapping("/{id}")
+    public ResponseEntity<BaseResponse<MatchingResponseDto>> cancelMatching(
+            @PathVariable Long id,
+            @AuthenticationPrincipal PrincipalDetails principalDetails) {
+
+        MatchingResponseDto response = matchingService.cancelMatching(id, principalDetails.getId());
+        return ResponseEntity.ok(
+                BaseResponse.success(response, BaseResponseStatus.MATCHING_CANCEL_SUCCESS.getMessage()));
     }
 }

--- a/src/main/java/com/mindgoal/domain/matching/entity/MatchingStatus.java
+++ b/src/main/java/com/mindgoal/domain/matching/entity/MatchingStatus.java
@@ -7,7 +7,8 @@ public enum MatchingStatus {
     PENDING("대기중"),
     ACCEPTED("수락됨"),
     REJECTED("거절됨"),
-    COMPLETED("완료됨");
+    COMPLETED("완료됨"),
+    CANCELED("취소됨");
 
     private final String description;
 

--- a/src/main/java/com/mindgoal/domain/matching/service/MatchingService.java
+++ b/src/main/java/com/mindgoal/domain/matching/service/MatchingService.java
@@ -47,23 +47,37 @@ public class MatchingService {
      */
     @Transactional
     public MatchingResponseDto cancelMatching(Long matchingId, Long userId) {
-        // 매칭 존재 여부 확인
-        Matching matching = matchingRepository.findById(matchingId)
-                .orElseThrow(() -> new CustomException(BaseResponseStatus.MATCHING_NOT_FOUND));
+        // 매칭 조회
+        Matching matching = findMatchingById(matchingId);
 
-        // 요청자 확인
-        if (!matching.getUserId().equals(userId)) {
-            throw new CustomException(BaseResponseStatus.UNAUTHORIZED_ACCESS);
-        }
-
-        // 이미 취소된 매칭인지 확인
-        if (matching.getStatus().equals(MatchingStatus.CANCELED.name())) {
-            throw new CustomException(BaseResponseStatus.MATCHING_ALREADY_CANCELED);
-        }
+        // 매칭 검증
+        validateMatching(matching, userId);
 
         // 매칭 상태 변경
         matching.updateStatus(MatchingStatus.CANCELED.name());
 
         return MatchingResponseDto.from(matching);
+    }
+
+    private Matching findMatchingById(Long matchingId) {
+        return matchingRepository.findById(matchingId)
+                .orElseThrow(() -> new CustomException(BaseResponseStatus.MATCHING_NOT_FOUND));
+    }
+
+    private void validateMatching(Matching matching, Long userId) {
+        validateMatchingOwner(matching, userId);
+        validateMatchingStatus(matching);
+    }
+
+    private void validateMatchingOwner(Matching matching, Long userId) {
+        if (!matching.getUserId().equals(userId)) {
+            throw new CustomException(BaseResponseStatus.UNAUTHORIZED_ACCESS);
+        }
+    }
+
+    private void validateMatchingStatus(Matching matching) {
+        if (matching.getStatus().equals(MatchingStatus.CANCELED.name())) {
+            throw new CustomException(BaseResponseStatus.MATCHING_ALREADY_CANCELED);
+        }
     }
 }

--- a/src/main/java/com/mindgoal/domain/matching/service/MatchingService.java
+++ b/src/main/java/com/mindgoal/domain/matching/service/MatchingService.java
@@ -25,7 +25,6 @@ public class MatchingService {
         Expert expert = expertRepository.findById(requestDto.getExpertId())
                 .orElseThrow(() -> new CustomException(BaseResponseStatus.EXPERT_NOT_FOUND));
 
-
         Matching matching = Matching.builder()
                 .userId(userId)
                 .expertId(requestDto.getExpertId())
@@ -37,5 +36,34 @@ public class MatchingService {
         Matching savedMatching = matchingRepository.save(matching);
 
         return MatchingResponseDto.from(savedMatching);
+    }
+
+    /**
+     * 매칭을 취소하는 메서드
+     *
+     * @param matchingId 매칭 ID
+     * @param userId 사용자 ID
+     * @return 취소된 매칭 정보
+     */
+    @Transactional
+    public MatchingResponseDto cancelMatching(Long matchingId, Long userId) {
+        // 매칭 존재 여부 확인
+        Matching matching = matchingRepository.findById(matchingId)
+                .orElseThrow(() -> new CustomException(BaseResponseStatus.MATCHING_NOT_FOUND));
+
+        // 요청자 확인
+        if (!matching.getUserId().equals(userId)) {
+            throw new CustomException(BaseResponseStatus.UNAUTHORIZED_ACCESS);
+        }
+
+        // 이미 취소된 매칭인지 확인
+        if (matching.getStatus().equals(MatchingStatus.CANCELED.name())) {
+            throw new CustomException(BaseResponseStatus.MATCHING_ALREADY_CANCELED);
+        }
+
+        // 매칭 상태 변경
+        matching.updateStatus(MatchingStatus.CANCELED.name());
+
+        return MatchingResponseDto.from(matching);
     }
 }

--- a/src/test/java/com/mindgoal/backend/matching/service/MatchingServiceTest.java
+++ b/src/test/java/com/mindgoal/backend/matching/service/MatchingServiceTest.java
@@ -17,8 +17,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import java.time.LocalDate;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -65,54 +63,74 @@ class MatchingServiceTest {
                     assertThat(matchingResponse.getStatus()).isEqualTo(MatchingStatus.PENDING.name());
                     assertThat(matchingResponse.getRequestMessage()).isEqualTo("축구 기술 향상을 위한 코칭 요청드립니다.");
                 });
-
-        // DB 검증
-        Matching foundMatching = matchingRepository.findById(response.getId())
-                .orElseThrow(() -> new AssertionError("Matching should exist"));
-
-        assertThat(foundMatching)
-                .satisfies(matching -> {
-                    assertThat(matching.getUserId()).isEqualTo(user.getId());
-                    assertThat(matching.getExpertId()).isEqualTo(expert.getId());
-                    assertThat(matching.getStatus()).isEqualTo(MatchingStatus.PENDING.name());
-                    assertThat(matching.getRequestMessage()).isEqualTo("축구 기술 향상을 위한 코칭 요청드립니다.");
-                });
     }
 
-    @DisplayName("존재하지 않는 전문가에게 매칭 요청 시 실패")
+    @DisplayName("매칭 취소 성공")
     @Test
-    void requestMatching_ExpertNotFound_ThrowsException() {
-        // given
-        User user = createUser("user@example.com", "사용자");
-        Long nonExistentExpertId = 999L;
-
-        MatchingRequestDto request = createMatchingRequest(nonExistentExpertId);
-
-        // when & then
-        assertThrows(CustomException.class,
-                () -> matchingService.requestMatching(user.getId(), request));
-    }
-
-    @DisplayName("매칭 요청 시 기본 상태는 PENDING")
-    @Test
-    void requestMatching_DefaultStatusIsPending() {
+    void cancelMatching_Success() {
         // given
         User user = createUser("user@example.com", "사용자");
         User expertUser = createUser("expert@example.com", "전문가");
         Expert expert = createExpert(expertUser.getId());
 
-        MatchingRequestDto request = createMatchingRequest(expert.getId());
+        // 매칭 생성
+        Matching matching = createMatching(user.getId(), expert.getId());
 
         // when
-        MatchingResponseDto response = matchingService.requestMatching(user.getId(), request);
+        MatchingResponseDto response = matchingService.cancelMatching(matching.getId(), user.getId());
 
         // then
-        assertThat(response.getStatus()).isEqualTo(MatchingStatus.PENDING.name());
+        assertThat(response.getStatus()).isEqualTo(MatchingStatus.CANCELED.name());
 
         // DB 검증
-        Matching foundMatching = matchingRepository.findById(response.getId())
+        Matching foundMatching = matchingRepository.findById(matching.getId())
                 .orElseThrow(() -> new AssertionError("Matching should exist"));
-        assertThat(foundMatching.getStatus()).isEqualTo(MatchingStatus.PENDING.name());
+        assertThat(foundMatching.getStatus()).isEqualTo(MatchingStatus.CANCELED.name());
+    }
+
+    @DisplayName("존재하지 않는 매칭 취소 시 실패")
+    @Test
+    void cancelMatching_NotFound_ThrowsException() {
+        // given
+        User user = createUser("user@example.com", "사용자");
+        Long nonExistentMatchingId = 999L;
+
+        // when & then
+        assertThrows(CustomException.class,
+                () -> matchingService.cancelMatching(nonExistentMatchingId, user.getId()));
+    }
+
+    @DisplayName("타인의 매칭 취소 시 실패")
+    @Test
+    void cancelMatching_UnauthorizedAccess_ThrowsException() {
+        // given
+        User user = createUser("user@example.com", "사용자");
+        User otherUser = createUser("other@example.com", "다른사용자");
+        User expertUser = createUser("expert@example.com", "전문가");
+        Expert expert = createExpert(expertUser.getId());
+
+        // user의 매칭 생성
+        Matching matching = createMatching(user.getId(), expert.getId());
+
+        // when & then
+        assertThrows(CustomException.class,
+                () -> matchingService.cancelMatching(matching.getId(), otherUser.getId()));
+    }
+
+    @DisplayName("이미 취소된 매칭 취소 시 실패")
+    @Test
+    void cancelMatching_AlreadyCanceled_ThrowsException() {
+        // given
+        User user = createUser("user@example.com", "사용자");
+        User expertUser = createUser("expert@example.com", "전문가");
+        Expert expert = createExpert(expertUser.getId());
+
+        // 취소된 매칭 생성
+        Matching matching = createCanceledMatching(user.getId(), expert.getId());
+
+        // when & then
+        assertThrows(CustomException.class,
+                () -> matchingService.cancelMatching(matching.getId(), user.getId()));
     }
 
     private User createUser(String email, String name) {
@@ -151,5 +169,25 @@ class MatchingServiceTest {
                 .expertId(expertId)
                 .requestMessage("축구 기술 향상을 위한 코칭 요청드립니다.")
                 .build();
+    }
+
+    private Matching createMatching(Long userId, Long expertId) {
+        Matching matching = Matching.builder()
+                .userId(userId)
+                .expertId(expertId)
+                .status(MatchingStatus.PENDING.name())
+                .requestMessage("축구 기술 향상을 위한 코칭 요청드립니다.")
+                .build();
+        return matchingRepository.save(matching);
+    }
+
+    private Matching createCanceledMatching(Long userId, Long expertId) {
+        Matching matching = Matching.builder()
+                .userId(userId)
+                .expertId(expertId)
+                .status(MatchingStatus.CANCELED.name())
+                .requestMessage("취소된 요청입니다.")
+                .build();
+        return matchingRepository.save(matching);
     }
 }


### PR DESCRIPTION
# Pull Request

## 💡 PR 요약
매칭 취소 기능을 구현했습니다. 사용자가 이전에 요청한 매칭을 취소할 수 있는 API를 개발했습니다.

## 🔍 주요 변경사항
- MatchingService에 매칭 취소 기능 추가
- MatchingController에 매칭 취소 API 엔드포인트(GET /api/v1/matching/{id}) 구현
- BaseResponseStatus에 매칭 취소 관련 상태 코드 추가
- 매칭 취소 기능에 대한 단위 테스트 코드 작성

## 🔗 연관된 이슈


## ✅ 체크리스트
- [x] 테스트 코드를 작성하였나요?
- [x] 관련 문서를 업데이트하였나요?
- [ ] Breaking Change가 있나요?
- [x] 코드 포맷팅과 린트 검사를 완료하였나요?

## 🙏 리뷰어 참고사항


## 📋 추가 컨텍스트
