### PR TITLE
[Mind-23] 매칭 목록 조회 기능 추가

### DIFF
--- a/src/main/java/com/mindgoal/common/BaseResponseStatus.java
+++ b/src/main/java/com/mindgoal/common/BaseResponseStatus.java
@@ -11,6 +11,7 @@ public enum BaseResponseStatus {
     EXPERT_UPDATE_SUCCESS(true, 200, "전문가 정보 수정이 성공했습니다"),
     MATCHING_REQUEST_SUCCESS(true, 201, "매칭 요청이 성공했습니다"),
     MATCHING_CANCEL_SUCCESS(true, 200, "매칭 취소가 성공했습니다"),
+    MATCHING_LIST_SUCCESS(true, 200, "매칭 목록 조회가 성공했습니다"),
 
     // 400번대: Request 오류
     BAD_REQUEST(false, 400, "잘못된 요청입니다"),

--- a/src/main/java/com/mindgoal/domain/matching/controller/MatchingController.java
+++ b/src/main/java/com/mindgoal/domain/matching/controller/MatchingController.java
@@ -12,6 +12,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
+/**
+ * 매칭 API를 처리하는 컨트롤러 클래스
+ */
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/matching")
@@ -38,6 +43,7 @@ public class MatchingController {
     }
 
     /**
+     * 매칭 취소 API
      *
      * @param id 매칭 ID
      * @param principalDetails 인증된 사용자 정보
@@ -51,5 +57,20 @@ public class MatchingController {
         MatchingResponseDto response = matchingService.cancelMatching(id, principalDetails.getId());
         return ResponseEntity.ok(
                 BaseResponse.success(response, BaseResponseStatus.MATCHING_CANCEL_SUCCESS.getMessage()));
+    }
+
+    /**
+     * 내 매칭 목록 조회 API
+     *
+     * @param principalDetails 인증된 사용자 정보
+     * @return 매칭 목록
+     */
+    @GetMapping("/me")
+    public ResponseEntity<BaseResponse<List<MatchingResponseDto>>> getMyMatchings(
+            @AuthenticationPrincipal PrincipalDetails principalDetails) {
+
+        List<MatchingResponseDto> response = matchingService.getMyMatchings(principalDetails.getId());
+        return ResponseEntity.ok(
+                BaseResponse.success(response, BaseResponseStatus.MATCHING_LIST_SUCCESS.getMessage()));
     }
 }

--- a/src/main/java/com/mindgoal/domain/matching/repository/MatchingRepository.java
+++ b/src/main/java/com/mindgoal/domain/matching/repository/MatchingRepository.java
@@ -18,5 +18,5 @@ public interface MatchingRepository extends JpaRepository<Matching, Long> {
      * @param userId 사용자 ID
      * @return 매칭 목록
      */
-    List<Matching> findByUserId(Long userId);
+    List<Matching> findAllByUserId(Long userId);
 }

--- a/src/main/java/com/mindgoal/domain/matching/repository/MatchingRepository.java
+++ b/src/main/java/com/mindgoal/domain/matching/repository/MatchingRepository.java
@@ -4,6 +4,19 @@ import com.mindgoal.domain.matching.entity.Matching;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
+/**
+ * 매칭 정보를 데이터베이스에서 관리하는 레포지토리 인터페이스
+ */
 @Repository
 public interface MatchingRepository extends JpaRepository<Matching, Long> {
+
+    /**
+     * 사용자 ID로 매칭 목록 조회
+     *
+     * @param userId 사용자 ID
+     * @return 매칭 목록
+     */
+    List<Matching> findByUserId(Long userId);
 }

--- a/src/main/java/com/mindgoal/domain/matching/service/MatchingService.java
+++ b/src/main/java/com/mindgoal/domain/matching/service/MatchingService.java
@@ -78,10 +78,10 @@ public class MatchingService {
      */
     @Transactional(readOnly = true)
     public List<MatchingResponseDto> getMyMatchings(Long userId) {
-        List<Matching> matchings = matchingRepository.findByUserId(userId);
+        List<Matching> matchings = matchingRepository.findAllByUserId(userId);
 
         return matchings.stream()
                 .map(MatchingResponseDto::from)
-                .collect(Collectors.toList());
+                .toList();
     }
 }

--- a/src/main/java/com/mindgoal/domain/matching/service/MatchingService.java
+++ b/src/main/java/com/mindgoal/domain/matching/service/MatchingService.java
@@ -12,6 +12,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class MatchingService {
@@ -65,5 +68,20 @@ public class MatchingService {
         matching.updateStatus(MatchingStatus.CANCELED.name());
 
         return MatchingResponseDto.from(matching);
+    }
+
+    /**
+     * 사용자의 매칭 목록을 조회하는 메서드
+     *
+     * @param userId 사용자 ID
+     * @return 매칭 목록
+     */
+    @Transactional(readOnly = true)
+    public List<MatchingResponseDto> getMyMatchings(Long userId) {
+        List<Matching> matchings = matchingRepository.findByUserId(userId);
+
+        return matchings.stream()
+                .map(MatchingResponseDto::from)
+                .collect(Collectors.toList());
     }
 }

--- a/src/test/java/com/mindgoal/backend/matching/service/MatchingServiceTest.java
+++ b/src/test/java/com/mindgoal/backend/matching/service/MatchingServiceTest.java
@@ -17,6 +17,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -133,6 +135,87 @@ class MatchingServiceTest {
                 () -> matchingService.cancelMatching(matching.getId(), user.getId()));
     }
 
+    @DisplayName("내 매칭 목록 조회 성공")
+    @Test
+    void getMyMatchings_Success() {
+        // given
+        User user = createUser("user@example.com", "사용자");
+        User expertUser = createUser("expert@example.com", "전문가");
+        Expert expert = createExpert(expertUser.getId());
+
+        // 사용자의 매칭 3개 생성
+        Matching matching1 = createMatchingWithMessage(user.getId(), expert.getId(), "첫 번째 요청");
+        Matching matching2 = createMatchingWithMessage(user.getId(), expert.getId(), "두 번째 요청");
+        Matching matching3 = createMatchingWithMessage(user.getId(), expert.getId(), "세 번째 요청");
+
+        // when
+        List<MatchingResponseDto> responses = matchingService.getMyMatchings(user.getId());
+
+        // then
+        assertThat(responses).hasSize(3);
+
+        // 매칭 정보 확인
+        assertThat(responses)
+                .extracting(MatchingResponseDto::getUserId)
+                .containsOnly(user.getId());
+
+        assertThat(responses)
+                .extracting(MatchingResponseDto::getExpertId)
+                .containsOnly(expert.getId());
+
+        assertThat(responses)
+                .extracting(MatchingResponseDto::getRequestMessage)
+                .containsExactlyInAnyOrder("첫 번째 요청", "두 번째 요청", "세 번째 요청");
+    }
+
+    @DisplayName("매칭이 없는 경우 빈 목록 반환")
+    @Test
+    void getMyMatchings_EmptyList() {
+        // given
+        User user = createUser("user@example.com", "사용자");
+
+        // when
+        List<MatchingResponseDto> responses = matchingService.getMyMatchings(user.getId());
+
+        // then
+        assertThat(responses).isEmpty();
+    }
+
+    @DisplayName("다른 사용자의 매칭은 조회되지 않음")
+    @Test
+    void getMyMatchings_OtherUserMatchingsNotIncluded() {
+        // given
+        User user1 = createUser("user1@example.com", "사용자1");
+        User user2 = createUser("user2@example.com", "사용자2");
+        User expertUser = createUser("expert@example.com", "전문가");
+        Expert expert = createExpert(expertUser.getId());
+
+        // 사용자1의 매칭 2개 생성
+        Matching matching1 = createMatchingWithMessage(user1.getId(), expert.getId(), "사용자1의 요청1");
+        Matching matching2 = createMatchingWithMessage(user1.getId(), expert.getId(), "사용자1의 요청2");
+
+        // 사용자2의 매칭 1개 생성
+        Matching matching3 = createMatchingWithMessage(user2.getId(), expert.getId(), "사용자2의 요청");
+
+        // when
+        List<MatchingResponseDto> user1Responses = matchingService.getMyMatchings(user1.getId());
+        List<MatchingResponseDto> user2Responses = matchingService.getMyMatchings(user2.getId());
+
+        // then
+        assertThat(user1Responses).hasSize(2);
+        assertThat(user2Responses).hasSize(1);
+
+        // 사용자1의 매칭만 조회되는지 확인
+        assertThat(user1Responses)
+                .extracting(MatchingResponseDto::getRequestMessage)
+                .containsExactlyInAnyOrder("사용자1의 요청1", "사용자1의 요청2");
+
+        // 사용자2의 매칭만 조회되는지 확인
+        assertThat(user2Responses)
+                .extracting(MatchingResponseDto::getRequestMessage)
+                .containsExactly("사용자2의 요청");
+    }
+
     private User createUser(String email, String name) {
         User user = User.builder()
                 .email(email)
@@ -177,6 +260,16 @@ class MatchingServiceTest {
                 .expertId(expertId)
                 .status(MatchingStatus.PENDING.name())
                 .requestMessage("축구 기술 향상을 위한 코칭 요청드립니다.")
+                .build();
+        return matchingRepository.save(matching);
+    }
+
+    private Matching createMatchingWithMessage(Long userId, Long expertId, String requestMessage) {
+        Matching matching = Matching.builder()
+                .userId(userId)
+                .expertId(expertId)
+                .status(MatchingStatus.PENDING.name())
+                .requestMessage(requestMessage)
                 .build();
         return matchingRepository.save(matching);
     }


### PR DESCRIPTION
# Pull Request

## 💡 PR 요약
매칭 목록 조회 기능을 추가했습니다. 사용자가 본인의 매칭 목록을 조회할 수 있는 기능을 구현했습니다.

## 🔍 주요 변경사항
- 매칭 엔티티에 내 매칭 목록 조회 기능 추가
- 매칭 저장소(Repository)에 findByUserId 메서드 구현
- 내 매칭 목록 조회 API 컨트롤러 엔드포인트 추가
- 매칭 서비스에 getMyMatchings 메서드 구현
- 매칭 목록 조회 기능 테스트 코드 작성

## 🔗 연관된 이슈
#23 내 매칭 목록 조회 기능 구현

## ✅ 체크리스트
- [x] 테스트 코드를 작성하였나요?
- [x] 관련 문서를 업데이트하였나요?
- [ ] Breaking Change가 있나요?
- [x] 코드 포맷팅과 린트 검사를 완료하였나요?

## 🙏 리뷰어 참고사항


## 📋 추가 컨텍스트
